### PR TITLE
Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,12 @@ plugins {
 	id 'groovy'
 }
 
+configurations.each { println it.name }
+
+
 group = 'rocks.metaldetector'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
 
 springBoot {
 	mainClassName = 'rocks.metaldetector.butler.MetalReleaseButlerApplication'
@@ -14,10 +17,13 @@ springBoot {
 
 def swaggerVersion = '2.9.2'
 def junitVersion = '5.6.0'
+//def spockVersion = '2.0-M2-groovy-2.5'
+//def groovyVersion = '2.5.10'
 def spockVersion = '2.0-M2-groovy-3.0'
 def groovyVersion = '3.0.1'
 def mySqlVersion = '5.1.48'
 def restAssuredVersion = '4.2.0'
+def jaxbOsgiVersion = '2.3.1'
 
 configurations {
 	developmentOnly
@@ -40,7 +46,6 @@ dependencies {
 	implementation "org.codehaus.groovy:groovy-all:$groovyVersion"
 	implementation "io.springfox:springfox-swagger2:$swaggerVersion"
 	implementation "io.springfox:springfox-swagger-ui:$swaggerVersion"
-	implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.4.0-b180830.0359'
 	developmentOnly "org.springframework.boot:spring-boot-devtools"
 	runtimeOnly "com.h2database:h2"
 	runtimeOnly "mysql:mysql-connector-java:$mySqlVersion"
@@ -49,13 +54,14 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test") {
 		exclude group: 'junit', module: 'junit'
 	}
-	testCompile("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-	testRuntime("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-	testCompile("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-	testCompile("org.spockframework:spock-core:$spockVersion")
-	testCompile("org.spockframework:spock-spring:$spockVersion")
-	testCompile("io.rest-assured:rest-assured:$restAssuredVersion")
-	testCompile("io.rest-assured:json-path:$restAssuredVersion")
+	testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+	testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+	testImplementation "org.spockframework:spock-core:$spockVersion"
+	testImplementation "org.spockframework:spock-spring:$spockVersion"
+	testImplementation "io.rest-assured:rest-assured:$restAssuredVersion"
+	testImplementation "io.rest-assured:json-path:$restAssuredVersion"
+	testImplementation "com.sun.xml.bind:jaxb-osgi:$jaxbOsgiVersion"
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-	id 'org.springframework.boot' version '2.1.9.RELEASE'
-	id 'io.spring.dependency-management' version '1.0.8.RELEASE'
+	id 'org.springframework.boot' version '2.2.5.RELEASE'
+	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'groovy'
 }
 
@@ -13,11 +13,11 @@ springBoot {
 }
 
 def swaggerVersion = '2.9.2'
-def junitVersion = '5.3.2'
-def spockVersion = '1.3-groovy-2.5'
-def groovyVersion = '2.5.8'
+def junitVersion = '5.6.0'
+def spockVersion = '2.0-M2-groovy-3.0'
+def groovyVersion = '3.0.1'
 def mySqlVersion = '5.1.48'
-def restAssuredVersion = '3.3.0'
+def restAssuredVersion = '4.2.0'
 
 configurations {
 	developmentOnly
@@ -40,6 +40,7 @@ dependencies {
 	implementation "org.codehaus.groovy:groovy-all:$groovyVersion"
 	implementation "io.springfox:springfox-swagger2:$swaggerVersion"
 	implementation "io.springfox:springfox-swagger-ui:$swaggerVersion"
+	implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.4.0-b180830.0359'
 	developmentOnly "org.springframework.boot:spring-boot-devtools"
 	runtimeOnly "com.h2database:h2"
 	runtimeOnly "mysql:mysql-connector-java:$mySqlVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ configurations.each { println it.name }
 
 group = 'rocks.metaldetector'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 springBoot {
 	mainClassName = 'rocks.metaldetector.butler.MetalReleaseButlerApplication'

--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,8 @@ springBoot {
 
 def swaggerVersion = '2.9.2'
 def junitVersion = '5.6.0'
-//def spockVersion = '2.0-M2-groovy-2.5'
-//def groovyVersion = '2.5.10'
 def spockVersion = '2.0-M2-groovy-3.0'
-def groovyVersion = '3.0.1'
+def groovyVersion = '3.0.2'
 def mySqlVersion = '5.1.48'
 def restAssuredVersion = '4.2.0'
 def jaxbOsgiVersion = '2.3.1'
@@ -43,7 +41,27 @@ dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-data-jpa"
 	implementation "org.springframework.boot:spring-boot-starter-web"
 	implementation "org.apache.httpcomponents:httpclient"
-	implementation "org.codehaus.groovy:groovy-all:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-docgenerator:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-ant:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-groovysh:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-console:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-groovydoc:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-cli-picocli:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-datetime:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-jmx:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-json:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-jsr223:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-macro:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-nio:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-servlet:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-sql:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-swing:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-templates:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-test-junit5:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-test:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-testng:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-xml:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy:$groovyVersion"
 	implementation "io.springfox:springfox-swagger2:$swaggerVersion"
 	implementation "io.springfox:springfox-swagger-ui:$swaggerVersion"
 	developmentOnly "org.springframework.boot:spring-boot-devtools"

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,6 @@ def junitVersion = '5.6.0'
 def spockVersion = '2.0-M2-groovy-3.0'
 def groovyVersion = '3.0.2'
 def mySqlVersion = '5.1.48'
-def restAssuredVersion = '4.2.0'
-def jaxbOsgiVersion = '2.3.1'
 
 configurations {
 	developmentOnly
@@ -77,9 +75,6 @@ dependencies {
 	testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
 	testImplementation "org.spockframework:spock-core:$spockVersion"
 	testImplementation "org.spockframework:spock-spring:$spockVersion"
-	testImplementation "io.rest-assured:rest-assured:$restAssuredVersion"
-	testImplementation "io.rest-assured:json-path:$restAssuredVersion"
-	testImplementation "com.sun.xml.bind:jaxb-osgi:$jaxbOsgiVersion"
 }
 
 test {

--- a/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
@@ -1,11 +1,5 @@
 package rocks.metaldetector.butler.web.rest
 
-import rocks.metaldetector.butler.model.TimeRange
-import rocks.metaldetector.butler.service.ReleaseService
-import rocks.metaldetector.butler.web.dto.ReleaseImportResponse
-import rocks.metaldetector.butler.web.dto.ReleasesRequest
-import rocks.metaldetector.butler.web.dto.ReleasesRequestPaginated
-import rocks.metaldetector.butler.web.dto.ReleasesResponse
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -14,10 +8,17 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import rocks.metaldetector.butler.model.TimeRange
+import rocks.metaldetector.butler.service.ReleaseService
+import rocks.metaldetector.butler.web.dto.ReleaseImportResponse
+import rocks.metaldetector.butler.web.dto.ReleasesRequest
+import rocks.metaldetector.butler.web.dto.ReleasesRequestPaginated
+import rocks.metaldetector.butler.web.dto.ReleasesResponse
 
 import javax.validation.Valid
 
-import static rocks.metaldetector.butler.config.Endpoints.*
+import static rocks.metaldetector.butler.config.Endpoints.RELEASES
+import static rocks.metaldetector.butler.config.Endpoints.UNPAGINATED
 
 @RestController
 @RequestMapping(RELEASES)

--- a/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerIT.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerIT.groovy
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.spockframework.spring.SpringBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -30,7 +29,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static rocks.metaldetector.butler.DtoFactory.ReleaseDtoFactory
 
 @TestPropertySource(locations = "classpath:application-test.properties")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
+@AutoConfigureMockMvc
 class ReleasesRestControllerIT extends Specification {
 
   static final String ARTIST_NAME = "A1"


### PR DESCRIPTION
All our dependencies are now up to date.
There were some issues with groovy-all (groovy 2.5.x was loaded, but 3.0.2 defined in gradle) so I had to import all the groovy modules separately. I guess it's SETT and we just check later if '-all' works again. Also I threw out the RestAssured dependency as I didn't manage to get it running in the Integration Test and just used MockMvc instead.