### PR TITLE
All release infos sent

### DIFF
--- a/src/main/groovy/rocks/metaldetector/butler/config/web/RestTemplateConfig.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/config/web/RestTemplateConfig.groovy
@@ -42,7 +42,7 @@ class RestTemplateConfig {
   @Bean
   ObjectMapper objectMapper() {
     ObjectMapper objectMapper = new ObjectMapper()
-    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
     objectMapper.registerModule(new JavaTimeModule())
     objectMapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/src/main/groovy/rocks/metaldetector/butler/service/ReleaseServiceImpl.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/ReleaseServiceImpl.groovy
@@ -137,7 +137,13 @@ class ReleaseServiceImpl implements ReleaseService {
         additionalArtists: releaseEntity.additionalArtists,
         albumTitle: releaseEntity.albumTitle,
         releaseDate: releaseEntity.releaseDate,
-        estimatedReleaseDate: releaseEntity.estimatedReleaseDate
+        estimatedReleaseDate: releaseEntity.estimatedReleaseDate,
+        genre: releaseEntity.genre,
+        type: releaseEntity.type,
+        metalArchivesAlbumUrl: releaseEntity.metalArchivesAlbumUrl,
+        metalArchivesArtistUrl: releaseEntity.metalArchivesArtistUrl,
+        source: releaseEntity.source,
+        state: releaseEntity.state
     )
   }
 }

--- a/src/main/groovy/rocks/metaldetector/butler/web/dto/ReleaseDto.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/dto/ReleaseDto.groovy
@@ -1,6 +1,9 @@
 package rocks.metaldetector.butler.web.dto
 
 import groovy.transform.Canonical
+import rocks.metaldetector.butler.model.release.ReleaseEntityRecordState
+import rocks.metaldetector.butler.model.release.ReleaseSource
+import rocks.metaldetector.butler.model.release.ReleaseType
 
 import java.time.LocalDate
 
@@ -12,5 +15,11 @@ class ReleaseDto {
   String albumTitle
   LocalDate releaseDate
   String estimatedReleaseDate
+  String genre
+  ReleaseType type
+  String metalArchivesArtistUrl
+  String metalArchivesAlbumUrl
+  ReleaseSource source
+  ReleaseEntityRecordState state
 
 }

--- a/src/test/groovy/rocks/metaldetector/butler/DtoFactory.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/DtoFactory.groovy
@@ -19,7 +19,9 @@ class DtoFactory {
   static class ReleaseDtoFactory {
 
     static ReleaseDto createReleaseDto(String artist, LocalDate releaseDate) {
-      return new ReleaseDto(artist, [artist], "T", releaseDate, "releaseDate")
+      return new ReleaseDto(artist: artist, additionalArtists: [artist], albumTitle: "T",
+                            releaseDate: releaseDate, estimatedReleaseDate: "releaseDate",
+                            state: ReleaseEntityRecordState.OK)
     }
   }
 }


### PR DESCRIPTION
I just mapped everything we have and we'll see what we show in the Detector.
I also configrued the ObjectMapper in our RestTemplate to serialize empty lists. This fixed an NPE in the response trafo in the Detector when the releases table is empty.