### PR TITLE
dateFrom has to be equal to or earlier than dateTo

### DIFF
--- a/src/main/groovy/rocks/metaldetector/butler/web/dto/ReleasesRequestPaginated.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/dto/ReleasesRequestPaginated.groovy
@@ -3,6 +3,7 @@ package rocks.metaldetector.butler.web.dto
 import groovy.transform.Canonical
 import org.springframework.format.annotation.DateTimeFormat
 
+import javax.validation.constraints.AssertTrue
 import javax.validation.constraints.Max
 import javax.validation.constraints.Min
 import java.time.LocalDate
@@ -29,4 +30,11 @@ class ReleasesRequestPaginated {
     return artists ?: Collections.emptyList() as Iterable<String>
   }
 
+  @AssertTrue(message = "If dates are set, dateFrom has to be equal to or before dateTo!")
+  private boolean isValid() {
+    if (dateFrom != null && dateTo != null) {
+      return dateFrom == dateTo || dateFrom.isBefore(dateTo)
+    }
+    return true
+  }
 }

--- a/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerTest.groovy
@@ -382,7 +382,9 @@ class ReleasesRestControllerTest extends Specification {
              new ReleasesRequestPaginated(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1),
                                           dateTo: LocalDate.of(2020, 2, 1), page: 1, size: 51),
              new ReleasesRequestPaginated(dateFrom: LocalDate.of(2020, 1, 1), dateTo: LocalDate.of(2020, 2, 1),
-                                          page: 1, size: 51)]
+                                          page: 1, size: 51),
+             new ReleasesRequestPaginated(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1), dateTo: LocalDate.of(2019, 1, 1),
+                                          page: 1, size: 10)]
   }
 
   def "Requesting import endpoint with correct action should return ok"() {


### PR DESCRIPTION
I implemented a validation method inside the `ReleasesRequestPaginated` class. This is kind of the "easy way out" instead of implementing a custom validator with annotations. I tried that but there were some issues with groovy. It seems not to be possible to define an inner annotation class inside an annotation. This was needed in the example (see [here](https://stackoverflow.com/questions/1972933/cross-field-validation-with-hibernate-validator-jsr-303)) . In Java it works, I've tried it in the Detector.
I think this is GEFN :)