### PR TITLE
Create import job asynchronously

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,7 +21,7 @@ jobs:
           gradle-version: 6.3
           arguments: clean bootJar
       - name: Build the Docker image
-        run: docker build --no-cache=true --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%S'),VCS_REF=${{ github.ref }} -t metaldetector/metal-release-butler:$(date -u +'%Y%m%dT%H%M%S') .
+        run: docker build --no-cache=true --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%S'),VCS_REF=${{ github.ref }} -t metaldetector/metal-release-butler .
       - name: Publish to DockerHub with version tag
         uses: docker/build-push-action@v1
         with:

--- a/src/main/groovy/rocks/metaldetector/butler/config/AppConfig.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/config/AppConfig.groovy
@@ -6,12 +6,14 @@ import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 
 @Configuration
 @EnableJpaAuditing
 @EnableScheduling
+@EnableAsync
 @EnableCaching
 class AppConfig {
 

--- a/src/main/groovy/rocks/metaldetector/butler/config/constants/Endpoints.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/config/constants/Endpoints.groovy
@@ -2,8 +2,9 @@ package rocks.metaldetector.butler.config.constants
 
 class Endpoints {
 
-  public static final String RELEASES = '/rest/v1/releases'
-  public static final String UNPAGINATED = '/unpaginated'
+  public static final String RELEASES             = "/rest/v1/releases"
+  public static final String IMPORT_JOB           = "/rest/v1/releases/import"
+  public static final String RELEASES_UNPAGINATED = "/rest/v1/releases/unpaginated"
 
   static class AntPattern {
 

--- a/src/main/groovy/rocks/metaldetector/butler/model/importjob/ImportJobEntity.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/model/importjob/ImportJobEntity.groovy
@@ -1,0 +1,31 @@
+package rocks.metaldetector.butler.model.importjob
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.builder.Builder
+import rocks.metaldetector.butler.model.BaseEntity
+
+import javax.persistence.Column
+import javax.persistence.Entity
+import java.time.LocalDateTime
+
+@Entity(name = "import_jobs")
+@EqualsAndHashCode(callSuper = false)
+@Builder(excludes = "new") // because there is method isNew in super class
+class ImportJobEntity extends BaseEntity {
+
+  @Column(name = "job_id", nullable = false)
+  UUID jobId
+
+  @Column(name = "total_count_requested", nullable = true)
+  int totalCountRequested
+
+  @Column(name = "total_count_imported", nullable = true)
+  int totalCountImported
+
+  @Column(name = "start_time", nullable = false, columnDefinition = "timestamp")
+  LocalDateTime startTime
+
+  @Column(name = "end_time", nullable = true, columnDefinition = "timestamp")
+  LocalDateTime endTime
+
+}

--- a/src/main/groovy/rocks/metaldetector/butler/model/importjob/ImportJobRepository.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/model/importjob/ImportJobRepository.groovy
@@ -1,0 +1,7 @@
+package rocks.metaldetector.butler.model.importjob
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ImportJobRepository extends JpaRepository<ImportJobEntity, Long> {
+
+}

--- a/src/main/groovy/rocks/metaldetector/butler/model/importjob/ImportJobRepository.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/model/importjob/ImportJobRepository.groovy
@@ -1,7 +1,9 @@
 package rocks.metaldetector.butler.model.importjob
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
+@Repository
 interface ImportJobRepository extends JpaRepository<ImportJobEntity, Long> {
 
 }

--- a/src/main/groovy/rocks/metaldetector/butler/model/release/ReleaseEntity.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/model/release/ReleaseEntity.groovy
@@ -63,5 +63,4 @@ class ReleaseEntity extends BaseEntity implements Comparable<ReleaseEntity> {
     // method is used for sorting and removing duplicates
     return this.releaseDate <=> other.releaseDate ?: this.artist <=> other.artist ?: this.albumTitle <=> other.albumTitle
   }
-
 }

--- a/src/main/groovy/rocks/metaldetector/butler/model/release/ReleaseRepository.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/model/release/ReleaseRepository.groovy
@@ -3,9 +3,11 @@ package rocks.metaldetector.butler.model.release
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
 import java.time.LocalDate
 
+@Repository
 interface ReleaseRepository extends JpaRepository<ReleaseEntity, Long> {
 
   Page<ReleaseEntity> findAllByReleaseDateAfter(LocalDate date, Pageable pageable)
@@ -24,8 +26,6 @@ interface ReleaseRepository extends JpaRepository<ReleaseEntity, Long> {
 
   List<ReleaseEntity> findAllByArtistInAndReleaseDateBetween(Iterable<String> artistNames, LocalDate from, LocalDate to)
 
-  Optional<ReleaseEntity> findByArtistAndAlbumTitleAndReleaseDate(String artist, String albumTitle, LocalDate releaseDate)
-
   boolean existsByArtistAndAlbumTitleAndReleaseDate(String artist, String albumTitle, LocalDate releaseDate)
 
   long countByReleaseDateAfter(LocalDate date)
@@ -35,7 +35,5 @@ interface ReleaseRepository extends JpaRepository<ReleaseEntity, Long> {
   long countByReleaseDateBetween(LocalDate from, LocalDate to)
 
   long countByArtistInAndReleaseDateBetween(Iterable<String> artistNames, LocalDate from, LocalDate to)
-
-  int deleteByReleaseDateAfter(LocalDate date)
 
 }

--- a/src/main/groovy/rocks/metaldetector/butler/service/cover/MetalArchivesCoverFetcher.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/cover/MetalArchivesCoverFetcher.groovy
@@ -23,7 +23,8 @@ class MetalArchivesCoverFetcher implements CoverFetcher {
     currentAttempt = 0
     HTTPBuilder httpBuilder = httpBuilderFunction.apply(metalArchivesAlbumUrl)
     def releasePage = fetchReleasePage(httpBuilder)
-    def coverDiv = releasePage?."**"?.findAll { it.@id == ALBUM_COVER_HTML_ID }?.first()
+    def coverDivs = releasePage?."**"?.findAll { it.@id == ALBUM_COVER_HTML_ID }
+    def coverDiv = coverDivs ? coverDivs.first() : null
     def coverLink = coverDiv?.@href?.text() as String
     return coverLink ? new URL(coverLink) : null
   }

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportService.groovy
@@ -9,7 +9,7 @@ import rocks.metaldetector.butler.model.release.ReleaseRepository
 import rocks.metaldetector.butler.service.converter.Converter
 import rocks.metaldetector.butler.service.cover.CoverService
 import rocks.metaldetector.butler.supplier.metalarchives.MetalArchivesRestClient
-import rocks.metaldetector.butler.web.dto.ReleaseImportResponse
+import rocks.metaldetector.butler.web.dto.ImportJobResponse
 
 import java.util.concurrent.Future
 
@@ -33,7 +33,7 @@ class MetalArchivesReleaseImportService implements ReleaseImportService {
   ThreadPoolTaskExecutor releaseEntityPersistenceThreadPool
 
   @Override
-  ReleaseImportResponse importReleases() {
+  ImportJobResponse importReleases() {
     // query metal archives
     def upcomingReleasesRawData = restClient.requestReleases()
 
@@ -52,7 +52,8 @@ class MetalArchivesReleaseImportService implements ReleaseImportService {
     }
 
     futures*.get()
-    return new ReleaseImportResponse(totalCountRequested: upcomingReleasesRawData.size(), totalCountImported: inserted)
+    // ToDo DanielW: Handle Return Value
+    return new ImportJobResponse(totalCountRequested: upcomingReleasesRawData.size(), totalCountImported: inserted)
   }
 
   private PersistReleaseEntityTask createPersistReleaseEntityTask(ReleaseEntity releaseEntity) {

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportService.groovy
@@ -43,8 +43,8 @@ class MetalArchivesReleaseImportService implements ReleaseImportService {
   @Autowired
   ImportJobTransformer importJobTransformer
 
-  @Override
   @Async
+  @Override
   ImportJobResponse importReleases(Long internalJobId) {
     // query metal archives
     def upcomingReleasesRawData = restClient.requestReleases()
@@ -58,6 +58,7 @@ class MetalArchivesReleaseImportService implements ReleaseImportService {
     // update import job
     ImportJobEntity importJobEntity = updateImportJob(internalJobId, upcomingReleasesRawData.size(), inserted)
 
+    log.info("Import of new releases is done!")
     return importJobTransformer.transform(importJobEntity)
   }
 

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportService.groovy
@@ -2,15 +2,20 @@ package rocks.metaldetector.butler.service.release
 
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.stereotype.Service
+import rocks.metaldetector.butler.model.importjob.ImportJobEntity
+import rocks.metaldetector.butler.model.importjob.ImportJobRepository
 import rocks.metaldetector.butler.model.release.ReleaseEntity
 import rocks.metaldetector.butler.model.release.ReleaseRepository
 import rocks.metaldetector.butler.service.converter.Converter
 import rocks.metaldetector.butler.service.cover.CoverService
+import rocks.metaldetector.butler.service.transformer.ImportJobTransformer
 import rocks.metaldetector.butler.supplier.metalarchives.MetalArchivesRestClient
 import rocks.metaldetector.butler.web.dto.ImportJobResponse
 
+import java.time.LocalDateTime
 import java.util.concurrent.Future
 
 @Service
@@ -19,6 +24,9 @@ class MetalArchivesReleaseImportService implements ReleaseImportService {
 
   @Autowired
   ReleaseRepository releaseRepository
+
+  @Autowired
+  ImportJobRepository importJobRepository
 
   @Autowired
   MetalArchivesRestClient restClient
@@ -32,15 +40,28 @@ class MetalArchivesReleaseImportService implements ReleaseImportService {
   @Autowired
   ThreadPoolTaskExecutor releaseEntityPersistenceThreadPool
 
+  @Autowired
+  ImportJobTransformer importJobTransformer
+
   @Override
-  ImportJobResponse importReleases() {
+  @Async
+  ImportJobResponse importReleases(Long internalJobId) {
     // query metal archives
     def upcomingReleasesRawData = restClient.requestReleases()
 
     // convert raw string data into ReleaseEntity
     List<ReleaseEntity> releaseEntities = upcomingReleasesRawData.collectMany { releaseEntityConverter.convert(it) }
 
-    // insert new releases
+    // persist releases incl. cover download
+    int inserted = persistReleaseEntities(releaseEntities)
+
+    // update import job
+    ImportJobEntity importJobEntity = updateImportJob(internalJobId, upcomingReleasesRawData.size(), inserted)
+
+    return importJobTransformer.transform(importJobEntity)
+  }
+
+  private int persistReleaseEntities(List<ReleaseEntity> releaseEntities) {
     int inserted = 0
     List<Future> futures = []
 
@@ -52,8 +73,7 @@ class MetalArchivesReleaseImportService implements ReleaseImportService {
     }
 
     futures*.get()
-    // ToDo DanielW: Handle Return Value
-    return new ImportJobResponse(totalCountRequested: upcomingReleasesRawData.size(), totalCountImported: inserted)
+    return inserted
   }
 
   private PersistReleaseEntityTask createPersistReleaseEntityTask(ReleaseEntity releaseEntity) {
@@ -62,5 +82,14 @@ class MetalArchivesReleaseImportService implements ReleaseImportService {
             coverService: coverService,
             releaseRepository: releaseRepository
     )
+  }
+
+  private ImportJobEntity updateImportJob(Long internalJobId, int totalCountRequested, int totalCountImported) {
+    ImportJobEntity importJobEntity = importJobRepository.findById(internalJobId).get()
+    importJobEntity.totalCountRequested = totalCountRequested
+    importJobEntity.totalCountImported = totalCountImported
+    importJobEntity.endTime = LocalDateTime.now()
+
+    return importJobRepository.save(importJobEntity)
   }
 }

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/MetalHammerReleaseImportService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/MetalHammerReleaseImportService.groovy
@@ -1,6 +1,7 @@
 package rocks.metaldetector.butler.service.release
 
 import groovy.util.logging.Slf4j
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import rocks.metaldetector.butler.web.dto.ImportJobResponse
 
@@ -8,6 +9,7 @@ import rocks.metaldetector.butler.web.dto.ImportJobResponse
 @Slf4j
 class MetalHammerReleaseImportService implements ReleaseImportService {
 
+  @Async
   @Override
   ImportJobResponse importReleases(Long internalJobId) {
     throw new UnsupportedOperationException("not yet implemented")

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/MetalHammerReleaseImportService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/MetalHammerReleaseImportService.groovy
@@ -9,7 +9,7 @@ import rocks.metaldetector.butler.web.dto.ImportJobResponse
 class MetalHammerReleaseImportService implements ReleaseImportService {
 
   @Override
-  ImportJobResponse importReleases() {
+  ImportJobResponse importReleases(Long internalJobId) {
     throw new UnsupportedOperationException("not yet implemented")
   }
 }

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/MetalHammerReleaseImportService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/MetalHammerReleaseImportService.groovy
@@ -2,14 +2,14 @@ package rocks.metaldetector.butler.service.release
 
 import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Service
-import rocks.metaldetector.butler.web.dto.ReleaseImportResponse
+import rocks.metaldetector.butler.web.dto.ImportJobResponse
 
 @Service
 @Slf4j
 class MetalHammerReleaseImportService implements ReleaseImportService {
 
   @Override
-  ReleaseImportResponse importReleases() {
+  ImportJobResponse importReleases() {
     throw new UnsupportedOperationException("not yet implemented")
   }
 }

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseImportService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseImportService.groovy
@@ -1,9 +1,11 @@
 package rocks.metaldetector.butler.service.release
 
+import org.springframework.scheduling.annotation.Async
 import rocks.metaldetector.butler.web.dto.ImportJobResponse
 
 interface ReleaseImportService {
 
+  @Async
   ImportJobResponse importReleases(Long internalJobId)
 
 }

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseImportService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseImportService.groovy
@@ -1,9 +1,9 @@
 package rocks.metaldetector.butler.service.release
 
-import rocks.metaldetector.butler.web.dto.ReleaseImportResponse
+import rocks.metaldetector.butler.web.dto.ImportJobResponse
 
 interface ReleaseImportService {
 
-  ReleaseImportResponse importReleases()
+  ImportJobResponse importReleases()
 
 }

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseImportService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseImportService.groovy
@@ -4,6 +4,6 @@ import rocks.metaldetector.butler.web.dto.ImportJobResponse
 
 interface ReleaseImportService {
 
-  ImportJobResponse importReleases()
+  ImportJobResponse importReleases(Long internalJobId)
 
 }

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseService.groovy
@@ -1,12 +1,12 @@
 package rocks.metaldetector.butler.service.release
 
 import rocks.metaldetector.butler.model.TimeRange
+import rocks.metaldetector.butler.web.dto.CreateImportJobResponse
 import rocks.metaldetector.butler.web.dto.ReleaseDto
-import rocks.metaldetector.butler.web.dto.ReleaseImportResponse
 
 interface ReleaseService {
 
-  ReleaseImportResponse importFromExternalSources()
+  CreateImportJobResponse importFromExternalSources()
 
   // ToDo DanielW: Cache?
   List<ReleaseDto> findAllUpcomingReleases(Iterable<String> artistNames, int page, int size)

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseService.groovy
@@ -8,7 +8,6 @@ interface ReleaseService {
 
   CreateImportJobResponse importFromExternalSources()
 
-  // ToDo DanielW: Cache?
   List<ReleaseDto> findAllUpcomingReleases(Iterable<String> artistNames, int page, int size)
 
   List<ReleaseDto> findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, int page, int size)

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImpl.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImpl.groovy
@@ -9,8 +9,8 @@ import org.springframework.transaction.annotation.Transactional
 import rocks.metaldetector.butler.model.TimeRange
 import rocks.metaldetector.butler.model.release.ReleaseEntity
 import rocks.metaldetector.butler.model.release.ReleaseRepository
+import rocks.metaldetector.butler.web.dto.CreateImportJobResponse
 import rocks.metaldetector.butler.web.dto.ReleaseDto
-import rocks.metaldetector.butler.web.dto.ReleaseImportResponse
 
 import java.time.LocalDate
 
@@ -33,8 +33,10 @@ class ReleaseServiceImpl implements ReleaseService {
 
   @Override
   @Transactional
-  ReleaseImportResponse importFromExternalSources() {
-    return metalArchivesReleaseImportService.importReleases()
+  CreateImportJobResponse importFromExternalSources() {
+    metalArchivesReleaseImportService.importReleases()
+    CreateImportJobResponse response = new CreateImportJobResponse(jobId: UUID.randomUUID()) // ToDo DanielW: Handle return value
+    return response
   }
 
   @Override

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImpl.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImpl.groovy
@@ -7,12 +7,15 @@ import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import rocks.metaldetector.butler.model.TimeRange
+import rocks.metaldetector.butler.model.importjob.ImportJobEntity
+import rocks.metaldetector.butler.model.importjob.ImportJobRepository
 import rocks.metaldetector.butler.model.release.ReleaseEntity
 import rocks.metaldetector.butler.model.release.ReleaseRepository
 import rocks.metaldetector.butler.web.dto.CreateImportJobResponse
 import rocks.metaldetector.butler.web.dto.ReleaseDto
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Service
 @Slf4j
@@ -22,6 +25,9 @@ class ReleaseServiceImpl implements ReleaseService {
 
   @Autowired
   ReleaseRepository releaseRepository
+
+  @Autowired
+  ImportJobRepository importJobRepository
 
   @Autowired
   ReleaseImportService metalArchivesReleaseImportService
@@ -34,9 +40,19 @@ class ReleaseServiceImpl implements ReleaseService {
   @Override
   @Transactional
   CreateImportJobResponse importFromExternalSources() {
-    metalArchivesReleaseImportService.importReleases()
-    CreateImportJobResponse response = new CreateImportJobResponse(jobId: UUID.randomUUID()) // ToDo DanielW: Handle return value
+    ImportJobEntity importJobEntity = createImportJob()
+    metalArchivesReleaseImportService.importReleases(importJobEntity.id)
+    CreateImportJobResponse response = new CreateImportJobResponse(jobId: importJobEntity.jobId)
     return response
+  }
+
+  private ImportJobEntity createImportJob() {
+    ImportJobEntity importJobEntity = new ImportJobEntity(
+            jobId: UUID.randomUUID(),
+            startTime: LocalDateTime.now()
+    )
+    importJobEntity = importJobRepository.save(importJobEntity)
+    return importJobEntity
   }
 
   @Override

--- a/src/main/groovy/rocks/metaldetector/butler/service/transformer/ImportJobTransformer.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/transformer/ImportJobTransformer.groovy
@@ -1,0 +1,23 @@
+package rocks.metaldetector.butler.service.transformer
+
+import org.springframework.stereotype.Service
+import rocks.metaldetector.butler.model.importjob.ImportJobEntity
+import rocks.metaldetector.butler.web.dto.ImportJobResponse
+
+@Service
+class ImportJobTransformer {
+
+  ImportJobResponse transform(ImportJobEntity importJobEntity) {
+    if (importJobEntity) {
+      return new ImportJobResponse(
+              jobId: importJobEntity.jobId,
+              totalCountRequested: importJobEntity.totalCountRequested,
+              totalCountImported: importJobEntity.totalCountImported,
+              startTime: importJobEntity.startTime,
+              endTime: importJobEntity.endTime,
+      )
+    }
+
+    return null
+  }
+}

--- a/src/main/groovy/rocks/metaldetector/butler/web/dto/CreateImportJobResponse.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/dto/CreateImportJobResponse.groovy
@@ -3,9 +3,7 @@ package rocks.metaldetector.butler.web.dto
 import groovy.transform.Canonical
 
 @Canonical
-class ReleaseImportResponse {
+class CreateImportJobResponse {
 
-  int totalCountRequested
-  int totalCountImported
-
+  UUID jobId
 }

--- a/src/main/groovy/rocks/metaldetector/butler/web/dto/ImportJobResponse.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/dto/ImportJobResponse.groovy
@@ -1,0 +1,16 @@
+package rocks.metaldetector.butler.web.dto
+
+import groovy.transform.Canonical
+
+import java.time.LocalDateTime
+
+@Canonical
+class ImportJobResponse {
+
+  UUID jobId
+  int totalCountRequested
+  int totalCountImported
+  LocalDateTime startTime
+  LocalDateTime endTime
+
+}

--- a/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
@@ -4,46 +4,36 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import rocks.metaldetector.butler.model.TimeRange
 import rocks.metaldetector.butler.service.release.ReleaseService
-import rocks.metaldetector.butler.web.dto.ReleaseImportResponse
+import rocks.metaldetector.butler.web.dto.CreateImportJobResponse
 import rocks.metaldetector.butler.web.dto.ReleasesRequest
 import rocks.metaldetector.butler.web.dto.ReleasesRequestPaginated
 import rocks.metaldetector.butler.web.dto.ReleasesResponse
 
 import javax.validation.Valid
 
+import static rocks.metaldetector.butler.config.constants.Endpoints.IMPORT_JOB
 import static rocks.metaldetector.butler.config.constants.Endpoints.RELEASES
-import static rocks.metaldetector.butler.config.constants.Endpoints.UNPAGINATED
+import static rocks.metaldetector.butler.config.constants.Endpoints.RELEASES_UNPAGINATED
 
 @RestController
-@RequestMapping(RELEASES)
 class ReleasesRestController {
-
-  static final IMPORT_ACTION = "import"
 
   @Autowired
   ReleaseService releaseService
 
-  @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+  @PostMapping(path = IMPORT_JOB, produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasRole('ROLE_ADMINISTRATOR')")
-  ResponseEntity<ReleaseImportResponse> importReleases(@RequestParam("action") String action) {
-    if (action == IMPORT_ACTION) {
-      ReleaseImportResponse response = releaseService.importFromExternalSources()
-      return ResponseEntity.ok(response)
-    }
-    else {
-      throw new IllegalArgumentException("Only query param 'action=import' is supported for GET request!")
-    }
+  ResponseEntity<CreateImportJobResponse> createImportJob() {
+    CreateImportJobResponse response = releaseService.importFromExternalSources()
+    return ResponseEntity.ok(response)
   }
 
-  @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @PostMapping(path = RELEASES, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasRole('ROLE_USER')")
   ResponseEntity<ReleasesResponse> getPaginatedReleases(@Valid @RequestBody ReleasesRequestPaginated request) {
     def releases
@@ -68,7 +58,7 @@ class ReleasesRestController {
     return ResponseEntity.ok(response)
   }
 
-  @PostMapping(path = [UNPAGINATED], consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @PostMapping(path = RELEASES_UNPAGINATED, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasRole('ROLE_ADMINISTRATOR')")
   ResponseEntity<ReleasesResponse> getAllReleases(@Valid @RequestBody ReleasesRequest request) {
     def releases

--- a/src/main/resources/application-preview.yml
+++ b/src/main/resources/application-preview.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
 
 server:
   port: 8080

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
 
 server:
   port: 8080

--- a/src/test/groovy/rocks/metaldetector/butler/model/release/ReleaseEntityTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/model/release/ReleaseEntityTest.groovy
@@ -1,0 +1,86 @@
+package rocks.metaldetector.butler.model.release
+
+import spock.lang.Specification
+
+import java.time.LocalDate
+
+class ReleaseEntityTest extends Specification {
+
+  def "should be sort by release date at first"() {
+    given:
+    def release1 = new ReleaseEntity(
+            releaseDate: LocalDate.of(2020, 6, 1),
+            artist: "C",
+            albumTitle: "C"
+    )
+    def release2 = new ReleaseEntity(
+            releaseDate: LocalDate.of(2020, 6, 2),
+            artist: "B",
+            albumTitle: "B"
+    )
+    def release3 = new ReleaseEntity(
+            releaseDate: LocalDate.of(2020, 6, 3),
+            artist: "A",
+            albumTitle: "A"
+    )
+    def releaseEntities = [release3, release1, release2]
+
+    when:
+    Collections.sort(releaseEntities)
+
+    then:
+    releaseEntities == [release1, release2, release3]
+  }
+
+  def "should be sort by artist at second"() {
+    given:
+    def release1 = new ReleaseEntity(
+            releaseDate: LocalDate.of(2020, 6, 1),
+            artist: "A",
+            albumTitle: "C"
+    )
+    def release2 = new ReleaseEntity(
+            releaseDate: LocalDate.of(2020, 6, 1),
+            artist: "B",
+            albumTitle: "A"
+    )
+    def release3 = new ReleaseEntity(
+            releaseDate: LocalDate.of(2020, 6, 1),
+            artist: "C",
+            albumTitle: "A"
+    )
+    def releaseEntities = [release3, release1, release2]
+
+    when:
+    Collections.sort(releaseEntities)
+
+    then:
+    releaseEntities == [release1, release2, release3]
+  }
+
+  def "should be sort by album title as third"() {
+    given:
+    def release1 = new ReleaseEntity(
+            releaseDate: LocalDate.of(2020, 6, 1),
+            artist: "A",
+            albumTitle: "A"
+    )
+    def release2 = new ReleaseEntity(
+            releaseDate: LocalDate.of(2020, 6, 1),
+            artist: "A",
+            albumTitle: "B"
+    )
+    def release3 = new ReleaseEntity(
+            releaseDate: LocalDate.of(2020, 6, 1),
+            artist: "A",
+            albumTitle: "C"
+    )
+    def releaseEntities = [release3, release1, release2]
+
+    when:
+    Collections.sort(releaseEntities)
+
+    then:
+    releaseEntities == [release1, release2, release3]
+  }
+}

--- a/src/test/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportServiceTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportServiceTest.groovy
@@ -131,7 +131,6 @@ class MetalArchivesReleaseImportServiceTest extends Specification {
             createReleaseEntity("Metallica", LocalDate.now())
     ]
     underTest.releaseRepository.existsByArtistAndAlbumTitleAndReleaseDate(*_) >>> [true, false]
-    underTest.importJobRepository.findById(*_) >> Optional.of(new ImportJobEntity())
 
     when:
     underTest.importReleases()
@@ -150,7 +149,6 @@ class MetalArchivesReleaseImportServiceTest extends Specification {
     def transformedResponse = new ImportJobResponse()
     underTest.restClient.requestReleases() >> [new String[0]]
     underTest.releaseEntityConverter.convert(*_) >> [new ReleaseEntity()]
-    underTest.importJobRepository.findById(*_) >> Optional.of(importJobEntityMock)
     underTest.importJobRepository.save(*_) >> importJobEntityMock
 
     when:

--- a/src/test/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportServiceTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportServiceTest.groovy
@@ -5,7 +5,7 @@ import rocks.metaldetector.butler.model.release.ReleaseEntity
 import rocks.metaldetector.butler.model.release.ReleaseRepository
 import rocks.metaldetector.butler.service.converter.ReleaseEntityConverter
 import rocks.metaldetector.butler.supplier.metalarchives.MetalArchivesRestClient
-import rocks.metaldetector.butler.web.dto.ReleaseImportResponse
+import rocks.metaldetector.butler.web.dto.ImportJobResponse
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -105,8 +105,9 @@ class MetalArchivesReleaseImportServiceTest extends Specification {
     when:
     def response = underTest.importReleases()
 
+    // ToDo DanielW: Handle Test
     then:
-    response == new ReleaseImportResponse(
+    response == new ImportJobResponse(
             totalCountRequested: 2,
             totalCountImported: 1
     )

--- a/src/test/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportServiceTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/release/MetalArchivesReleaseImportServiceTest.groovy
@@ -1,9 +1,12 @@
 package rocks.metaldetector.butler.service.release
 
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import rocks.metaldetector.butler.model.importjob.ImportJobEntity
+import rocks.metaldetector.butler.model.importjob.ImportJobRepository
 import rocks.metaldetector.butler.model.release.ReleaseEntity
 import rocks.metaldetector.butler.model.release.ReleaseRepository
 import rocks.metaldetector.butler.service.converter.ReleaseEntityConverter
+import rocks.metaldetector.butler.service.transformer.ImportJobTransformer
 import rocks.metaldetector.butler.supplier.metalarchives.MetalArchivesRestClient
 import rocks.metaldetector.butler.web.dto.ImportJobResponse
 import spock.lang.Specification
@@ -17,10 +20,16 @@ class MetalArchivesReleaseImportServiceTest extends Specification {
 
   MetalArchivesReleaseImportService underTest = new MetalArchivesReleaseImportService(
           releaseRepository: Mock(ReleaseRepository),
+          importJobRepository: Mock(ImportJobRepository),
           restClient: Mock(MetalArchivesRestClient),
           releaseEntityConverter: Mock(ReleaseEntityConverter),
-          releaseEntityPersistenceThreadPool: Mock(ThreadPoolTaskExecutor)
+          releaseEntityPersistenceThreadPool: Mock(ThreadPoolTaskExecutor),
+          importJobTransformer: Mock(ImportJobTransformer)
   )
+
+  def setup() {
+    underTest.importJobRepository.findById(_) >> Optional.of(new ImportJobEntity())
+  }
 
   def "rest client is called once on import"() {
     when:
@@ -94,22 +103,63 @@ class MetalArchivesReleaseImportServiceTest extends Specification {
     0 * underTest.releaseEntityPersistenceThreadPool.submit(_)
   }
 
-  def "should return a summary about how much releases are requested and how much releases are imported"() {
+  def "should update the corresponding import job"() {
+    given:
+    def internalJobId = 666
+    def importJobEntityMock = new ImportJobEntity()
+    underTest.restClient.requestReleases() >> [new String[0]]
+    underTest.releaseEntityConverter.convert(_) >> [new ReleaseEntity()]
+
+    when:
+    underTest.importReleases(internalJobId)
+
+    then:
+    1 * underTest.importJobRepository.findById(internalJobId) >> Optional.of(importJobEntityMock)
+
+    then:
+    1 * underTest.importJobRepository.save({ args ->
+      assert args.totalCountRequested == 1
+      assert args.totalCountImported == 1
+      assert args.endTime
+    })
+  }
+
+  def "should update import job with correct values for 'totalCountRequested' and 'totalCountImported'"() {
     given:
     underTest.restClient.requestReleases() >> [new String[0], new String[0]]
     underTest.releaseEntityConverter.convert(_) >> [
             createReleaseEntity("Metallica", LocalDate.now())
     ]
     underTest.releaseRepository.existsByArtistAndAlbumTitleAndReleaseDate(*_) >>> [true, false]
+    underTest.importJobRepository.findById(*_) >> Optional.of(new ImportJobEntity())
 
     when:
-    def response = underTest.importReleases()
+    underTest.importReleases()
 
-    // ToDo DanielW: Handle Test
     then:
-    response == new ImportJobResponse(
-            totalCountRequested: 2,
-            totalCountImported: 1
-    )
+    1 * underTest.importJobRepository.save({ args ->
+      assert args.totalCountRequested == 2
+      assert args.totalCountImported == 1
+      assert args.endTime
+    })
+  }
+
+  def "should use ImportJobTransformer to transform ImportJobEntity that is used as result"() {
+    given:
+    def importJobEntityMock = new ImportJobEntity()
+    def transformedResponse = new ImportJobResponse()
+    underTest.restClient.requestReleases() >> [new String[0]]
+    underTest.releaseEntityConverter.convert(*_) >> [new ReleaseEntity()]
+    underTest.importJobRepository.findById(*_) >> Optional.of(importJobEntityMock)
+    underTest.importJobRepository.save(*_) >> importJobEntityMock
+
+    when:
+    def result = underTest.importReleases()
+
+    then:
+    1 * underTest.importJobTransformer.transform(importJobEntityMock) >> transformedResponse
+
+    and:
+    result == transformedResponse
   }
 }

--- a/src/test/groovy/rocks/metaldetector/butler/service/transformer/ImportJobTransformerTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/transformer/ImportJobTransformerTest.groovy
@@ -1,0 +1,76 @@
+package rocks.metaldetector.butler.service.transformer
+
+import rocks.metaldetector.butler.model.importjob.ImportJobEntity
+import spock.lang.Specification
+
+import java.time.LocalDateTime
+
+class ImportJobTransformerTest extends Specification {
+
+  ImportJobTransformer underTest = new ImportJobTransformer()
+
+  def "should be null safe"() {
+    expect:
+    underTest.transform(null) == null
+  }
+
+  def "should transform 'jobId'"() {
+    given:
+    def jobId = UUID.randomUUID()
+    def importJobEntity = new ImportJobEntity(jobId: jobId)
+
+    when:
+    def result = underTest.transform(importJobEntity)
+
+    then:
+    result.jobId == jobId
+  }
+
+  def "should transform 'totalCountRequested'"() {
+    given:
+    def totalCountRequested = 666
+    def importJobEntity = new ImportJobEntity(totalCountRequested: totalCountRequested)
+
+    when:
+    def result = underTest.transform(importJobEntity)
+
+    then:
+    result.totalCountRequested == totalCountRequested
+  }
+
+  def "should transform 'totalCountImported'"() {
+    given:
+    def totalCountImported = 666
+    def importJobEntity = new ImportJobEntity(totalCountImported: totalCountImported)
+
+    when:
+    def result = underTest.transform(importJobEntity)
+
+    then:
+    result.totalCountImported == totalCountImported
+  }
+
+  def "should transform 'startTime'"() {
+    given:
+    def startTime = LocalDateTime.now()
+    def importJobEntity = new ImportJobEntity(startTime: startTime)
+
+    when:
+    def result = underTest.transform(importJobEntity)
+
+    then:
+    result.startTime == startTime
+  }
+
+  def "should transform 'endTime'"() {
+    given:
+    def endTime = LocalDateTime.now()
+    def importJobEntity = new ImportJobEntity(endTime: endTime)
+
+    when:
+    def result = underTest.transform(importJobEntity)
+
+    then:
+    result.endTime == endTime
+  }
+}

--- a/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerIT.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerIT.groovy
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import rocks.metaldetector.butler.TokenFactory
-import rocks.metaldetector.butler.config.constants.Endpoints
 import rocks.metaldetector.butler.service.release.ReleaseService
 import rocks.metaldetector.butler.testutil.WithIntegrationTestConfig
 import rocks.metaldetector.butler.web.dto.ReleasesRequest
@@ -17,8 +16,10 @@ import rocks.metaldetector.butler.web.dto.ReleasesRequestPaginated
 import spock.lang.Specification
 
 import static org.mockito.Mockito.reset
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static rocks.metaldetector.butler.config.constants.Endpoints.IMPORT_JOB
+import static rocks.metaldetector.butler.config.constants.Endpoints.RELEASES
+import static rocks.metaldetector.butler.config.constants.Endpoints.RELEASES_UNPAGINATED
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -30,13 +31,9 @@ class ReleasesRestControllerIT extends Specification implements WithIntegrationT
   @Autowired
   MockMvc mockMvc
 
-  ObjectMapper objectMapper
+  ObjectMapper objectMapper = new ObjectMapper()
   String testAdminToken = TokenFactory.generateAdminTestToken()
   String testUserToken = TokenFactory.generateUserTestToken()
-
-  void setup() {
-    objectMapper = new ObjectMapper()
-  }
 
   void tearDown() {
     reset(releaseService)
@@ -45,7 +42,7 @@ class ReleasesRestControllerIT extends Specification implements WithIntegrationT
   def "User can access releases endpoint"() {
     given:
     def requestBody = new ReleasesRequestPaginated(page: 1, size: 10, artists: [])
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .content(objectMapper.writeValueAsString(requestBody))
         .contentType(MediaType.APPLICATION_JSON)
         .header("Authorization", "Bearer " + testUserToken)
@@ -60,7 +57,7 @@ class ReleasesRestControllerIT extends Specification implements WithIntegrationT
   def "Admin can access releases endpoint"() {
     given:
     def requestBody = new ReleasesRequestPaginated(page: 1, size: 10, artists: [])
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .content(objectMapper.writeValueAsString(requestBody))
         .contentType(MediaType.APPLICATION_JSON)
         .header("Authorization", "Bearer " + testAdminToken)
@@ -74,7 +71,7 @@ class ReleasesRestControllerIT extends Specification implements WithIntegrationT
 
   def "Admin can access import endpoint"() {
     given:
-    def request = get(Endpoints.RELEASES).param("action", "import").header("Authorization", "Bearer " + testAdminToken)
+    def request = post(IMPORT_JOB).header("Authorization", "Bearer " + testAdminToken)
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -86,7 +83,7 @@ class ReleasesRestControllerIT extends Specification implements WithIntegrationT
   def "Admin can access unpaginated releases endpoint"() {
     given:
     def requestBody = new ReleasesRequest(artists: [])
-    def request = post(Endpoints.RELEASES + Endpoints.UNPAGINATED)
+    def request = post(RELEASES_UNPAGINATED)
         .content(objectMapper.writeValueAsString(requestBody))
         .contentType(MediaType.APPLICATION_JSON)
         .header("Authorization", "Bearer " + testAdminToken)
@@ -101,7 +98,7 @@ class ReleasesRestControllerIT extends Specification implements WithIntegrationT
 
   def "User cannot access import endpoint"() {
     given:
-    def request = get(Endpoints.RELEASES).param("action", "import").header("Authorization", "Bearer " + testUserToken)
+    def request = post(IMPORT_JOB).header("Authorization", "Bearer " + testUserToken)
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -113,7 +110,7 @@ class ReleasesRestControllerIT extends Specification implements WithIntegrationT
   def "User cannot access unpaginated releases endpoint"() {
     given:
     def requestBody = new ReleasesRequest(artists: [])
-    def request = post(Endpoints.RELEASES + Endpoints.UNPAGINATED)
+    def request = post(RELEASES_UNPAGINATED)
         .content(objectMapper.writeValueAsString(requestBody))
         .contentType(MediaType.APPLICATION_JSON)
         .header("Authorization", "Bearer " + testUserToken)

--- a/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerTest.groovy
@@ -9,11 +9,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.accept.ContentNegotiationManager
 import org.springframework.web.servlet.HandlerExceptionResolver
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport
-import rocks.metaldetector.butler.config.constants.Endpoints
 import rocks.metaldetector.butler.model.TimeRange
 import rocks.metaldetector.butler.service.release.ReleaseService
+import rocks.metaldetector.butler.web.dto.CreateImportJobResponse
 import rocks.metaldetector.butler.web.dto.ReleaseDto
-import rocks.metaldetector.butler.web.dto.ReleaseImportResponse
 import rocks.metaldetector.butler.web.dto.ReleasesRequest
 import rocks.metaldetector.butler.web.dto.ReleasesRequestPaginated
 import rocks.metaldetector.butler.web.dto.ReleasesResponse
@@ -25,9 +24,11 @@ import java.time.LocalDate
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST
 import static org.springframework.http.HttpStatus.OK
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import static rocks.metaldetector.butler.DtoFactory.ReleaseDtoFactory
+import static rocks.metaldetector.butler.config.constants.Endpoints.IMPORT_JOB
+import static rocks.metaldetector.butler.config.constants.Endpoints.RELEASES
+import static rocks.metaldetector.butler.config.constants.Endpoints.RELEASES_UNPAGINATED
 
 class ReleasesRestControllerTest extends Specification {
 
@@ -51,7 +52,7 @@ class ReleasesRestControllerTest extends Specification {
     given:
     def artists = [ARTIST_NAME]
     def releasesRequest = new ReleasesRequest(artists: artists)
-    def request = post(Endpoints.RELEASES + Endpoints.UNPAGINATED)
+    def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
@@ -66,7 +67,7 @@ class ReleasesRestControllerTest extends Specification {
   def "Requesting unpaginated releases endpoint with valid request should return ok"() {
     given:
     def releasesRequest = new ReleasesRequest(artists: [ARTIST_NAME])
-    def request = post(Endpoints.RELEASES + Endpoints.UNPAGINATED)
+    def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
@@ -83,7 +84,7 @@ class ReleasesRestControllerTest extends Specification {
     given:
     def expectedReleases = getReleaseDtosForTimeRangeTest()
     def releasesRequest = new ReleasesRequest(artists: [ARTIST_NAME])
-    def request = post(Endpoints.RELEASES + Endpoints.UNPAGINATED)
+    def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
@@ -104,7 +105,7 @@ class ReleasesRestControllerTest extends Specification {
     def to = LocalDate.of(2020, 2, 1)
     def artists = [ARTIST_NAME]
     def requestDto = new ReleasesRequest(artists: artists, dateFrom: from, dateTo: to)
-    def request = post(Endpoints.RELEASES + Endpoints.UNPAGINATED)
+    def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto))
@@ -123,7 +124,7 @@ class ReleasesRestControllerTest extends Specification {
     def artists = [ARTIST_NAME]
     def requestDto = new ReleasesRequest(artists: artists, dateFrom: from, dateTo: to)
     def expectedReleases = [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31))]
-    def request = post(Endpoints.RELEASES + Endpoints.UNPAGINATED)
+    def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto))
@@ -143,7 +144,7 @@ class ReleasesRestControllerTest extends Specification {
     def artists = [ARTIST_NAME]
     def requestDto = new ReleasesRequest(artists: artists, dateFrom: from, dateTo: to)
     def expectedReleases = [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31))]
-    def request = post(Endpoints.RELEASES + Endpoints.UNPAGINATED)
+    def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto))
@@ -160,7 +161,7 @@ class ReleasesRestControllerTest extends Specification {
   @Unroll
   "Requesting unpaginated releases with bad request should not call releases service"() {
     given:
-    def request = post(Endpoints.RELEASES + Endpoints.UNPAGINATED)
+    def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(body))
@@ -180,7 +181,7 @@ class ReleasesRestControllerTest extends Specification {
   @Unroll
   "Requesting unpaginated releases with bad request should return bad request"() {
     given:
-    def request = post(Endpoints.RELEASES + Endpoints.UNPAGINATED)
+    def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(body))
@@ -200,7 +201,7 @@ class ReleasesRestControllerTest extends Specification {
     given:
     def artists = [ARTIST_NAME]
     def releasesRequest = new ReleasesRequestPaginated(artists: artists, page: 1, size: 10)
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
@@ -219,7 +220,7 @@ class ReleasesRestControllerTest extends Specification {
     given:
     def expectedReleases = getReleaseDtosForTimeRangeTest()
     def releasesRequest = new ReleasesRequestPaginated(artists: [ARTIST_NAME], page: 1, size: 10)
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
@@ -236,7 +237,7 @@ class ReleasesRestControllerTest extends Specification {
     given:
     def expectedReleases = getReleaseDtosForTimeRangeTest()
     def releasesRequest = new ReleasesRequestPaginated(artists: [ARTIST_NAME], page: 1, size: 10)
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
@@ -256,7 +257,7 @@ class ReleasesRestControllerTest extends Specification {
     given:
     def expectedReleases = getReleaseDtosForTimeRangeTest()
     def releasesRequest = new ReleasesRequestPaginated(artists: [ARTIST_NAME], page: 1, size: 10)
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
@@ -276,7 +277,7 @@ class ReleasesRestControllerTest extends Specification {
     def expectedPages = 3
     def expectedReleases = getReleaseDtosForPaginationTest()
     def releasesRequest = new ReleasesRequestPaginated(artists: [ARTIST_NAME], page: 1, size: 2)
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
@@ -298,7 +299,7 @@ class ReleasesRestControllerTest extends Specification {
     def to = LocalDate.of(2020, 2, 1)
     def artists = [ARTIST_NAME]
     def requestDto = new ReleasesRequestPaginated(artists: artists, dateFrom: from, dateTo: to, page: 1, size: 10)
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto))
@@ -320,7 +321,7 @@ class ReleasesRestControllerTest extends Specification {
     def artists = [ARTIST_NAME]
     def requestDto = new ReleasesRequestPaginated(artists: artists, dateFrom: from, dateTo: to, page: 1, size: 10)
     def expectedReleases = [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31))]
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto))
@@ -340,7 +341,7 @@ class ReleasesRestControllerTest extends Specification {
     def artists = [ARTIST_NAME]
     def requestDto = new ReleasesRequestPaginated(artists: artists, dateFrom: from, dateTo: to, page: 1, size: 10)
     def expectedReleases = [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31))]
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto))
@@ -357,7 +358,7 @@ class ReleasesRestControllerTest extends Specification {
   @Unroll
   "Requesting releases with bad request should return bad request"() {
     given:
-    def request = post(Endpoints.RELEASES)
+    def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(body))
@@ -387,24 +388,9 @@ class ReleasesRestControllerTest extends Specification {
                                           page: 1, size: 10)]
   }
 
-  def "Requesting import endpoint with correct action should return ok"() {
+  def "Creating import job should call release service"() {
     given:
-    def request = get(Endpoints.RELEASES)
-        .accept(MediaType.APPLICATION_JSON)
-        .param("action", "import")
-
-    when:
-    def result = mockMvc.perform(request).andReturn()
-
-    then:
-    result.response.status == OK.value()
-  }
-
-  def "Requesting import endpoint with correct action should call releases service"() {
-    given:
-    def request = get(Endpoints.RELEASES)
-        .accept(MediaType.APPLICATION_JSON)
-        .param("action", "import")
+    def request = post(IMPORT_JOB).accept(MediaType.APPLICATION_JSON)
 
     when:
     mockMvc.perform(request).andReturn()
@@ -413,49 +399,21 @@ class ReleasesRestControllerTest extends Specification {
     1 * underTest.releaseService.importFromExternalSources()
   }
 
-  def "Requesting import endpoint with correct action should return import result"() {
+  def "Creating import job should return result from release service"() {
     given:
-    def request = get(Endpoints.RELEASES)
-        .accept(MediaType.APPLICATION_JSON)
-        .param("action", "import")
-    def importResultDto = new ReleaseImportResponse(totalCountRequested: 666, totalCountImported: 666)
-    underTest.releaseService.importFromExternalSources() >> importResultDto
+    def request = post(IMPORT_JOB).accept(MediaType.APPLICATION_JSON)
+    def response = new CreateImportJobResponse(jobId: UUID.randomUUID())
+    underTest.releaseService.importFromExternalSources() >> response
 
     when:
     def result = mockMvc.perform(request).andReturn()
 
     then:
-    ReleaseImportResponse importResponse = objectMapper.readValue(result.response.getContentAsString(), ReleaseImportResponse)
-    importResponse.totalCountRequested == importResultDto.totalCountRequested
+    CreateImportJobResponse importJobResponse = objectMapper.readValue(result.response.contentAsString, CreateImportJobResponse)
+    importJobResponse == response
 
     and:
-    importResponse.totalCountImported == importResultDto.totalCountImported
-  }
-
-  def "Requesting import endpoint with any other action should return bad request"() {
-    given:
-    def request = get(Endpoints.RELEASES)
-        .accept(MediaType.APPLICATION_JSON)
-        .param("action", "download")
-
-    when:
-    def result = mockMvc.perform(request).andReturn()
-
-    then:
-    result.response.status == BAD_REQUEST.value()
-  }
-
-  def "Requesting import endpoint with any other action should not call releases service"() {
-    given:
-    def request = get(Endpoints.RELEASES)
-        .accept(MediaType.APPLICATION_JSON)
-        .param("action", "download")
-
-    when:
-    mockMvc.perform(request).andReturn()
-
-    then:
-    0 * underTest.releaseService.importFromExternalSources()
+    result.response.status == OK.value()
   }
 
   private static List<ReleaseDto> getReleaseDtosForTimeRangeTest() {


### PR DESCRIPTION
The import job endpoint now responds very quickly with a job id. The whole import process is made asynchronously.

The next step is to fetch all import job results so we can have a look at it from our admin area.