### PR TITLE
Dependency update and cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.2.5.RELEASE'
+	id 'org.springframework.boot' version '2.3.0.RELEASE'
 	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'groovy'
 	id 'jacoco'
@@ -15,8 +15,8 @@ springBoot {
 }
 
 def swaggerVersion = '2.9.2'
-def spockVersion = '2.0-M2-groovy-3.0'
-def groovyVersion = '3.0.2'
+def spockVersion = '2.0-M3-groovy-3.0'
+def groovyVersion = '3.0.4'
 def postgresqlVersion = '42.2.12'
 def bucket4JVersion = '0.2.0'
 def jsonwebtokenVersion = '0.9.1'
@@ -40,6 +40,7 @@ repositories {
 dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-data-jpa"
 	implementation "org.springframework.boot:spring-boot-starter-web"
+	implementation "org.springframework.boot:spring-boot-starter-validation"
 	implementation "org.springframework.boot:spring-boot-starter-security"
 	implementation "org.apache.httpcomponents:httpclient"
 
@@ -47,28 +48,7 @@ dependencies {
 	implementation "org.ehcache:ehcache"
 	implementation "com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:$bucket4JVersion"
 
-	// Groovy (https://trello.com/c/LYad48xw)
-	implementation "org.codehaus.groovy:groovy-docgenerator:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-ant:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-groovysh:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-console:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-groovydoc:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-cli-picocli:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-datetime:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-jmx:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-json:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-jsr223:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-macro:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-nio:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-servlet:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-sql:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-swing:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-templates:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-test-junit5:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-test:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-testng:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy-xml:$groovyVersion"
-	implementation "org.codehaus.groovy:groovy:$groovyVersion"
+	implementation "org.codehaus.groovy:groovy-all:$groovyVersion" exclude group:"org.codehaus.groovy", module: "groovy-testng"
 
 	implementation "org.codehaus.groovy.modules.http-builder:http-builder:$httpBuilderVersion"
 	implementation "commons-io:commons-io:$commonsIoVersion"
@@ -87,6 +67,32 @@ dependencies {
 	testImplementation "org.spockframework:spock-core:$spockVersion"
 	testImplementation "org.spockframework:spock-spring:$spockVersion"
 	testImplementation "org.springframework.security:spring-security-test"
+}
+
+ext {
+	dependencyVersions = ["commons-lang:commons-lang:2.4",
+												"org.junit:junit-bom:5.7.0-M1",
+												"org.ow2.asm:asm:8.0.1",
+												"org.objenesis:objenesis:3.1"]
+	dependencyGroupVersions = ["org.codehaus.groovy": groovyVersion]
+}
+
+allprojects {
+	configurations {
+		all {
+			resolutionStrategy {
+				failOnVersionConflict()
+				force dependencyVersions
+				eachDependency { DependencyResolveDetails details ->
+					def forcedVersion = dependencyGroupVersions[details.requested.group]
+					if (forcedVersion) {
+						details.useVersion forcedVersion
+					}
+				}
+				cacheDynamicVersionsFor 0, "seconds"
+			}
+		}
+	}
 }
 
 test {


### PR DESCRIPTION
Update of Spring Boot, Groovy and Spock. 
I was able to remove the single groovy imports with groovy-all by just forcing the new version. I also had to exclude testng because the currently used new version in groovy 3.0.4 is not yet present on maven central. We could get it from jcenter but at we don't use it anyways it's cleaner to exclude I think. More info on that [here](https://groovy-lang.org/releasenotes/groovy-3.0.html), search for `testng`.
Some other dependencies also had to be forced.