### PR TITLE
Nullsafety for cover download

### DIFF
--- a/src/main/groovy/rocks/metaldetector/butler/service/cover/CoverServiceImpl.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/cover/CoverServiceImpl.groovy
@@ -16,7 +16,9 @@ class CoverServiceImpl implements CoverService {
 
   @Override
   String transfer(URL sourceUrl) {
-    def coverUrl = metalArchivesCoverFetcher.fetchCoverUrl(sourceUrl)
-    return coverUrl ? coverPersistenceService.persistCover(coverUrl) : null
+    if (sourceUrl) {
+      def coverUrl = metalArchivesCoverFetcher.fetchCoverUrl(sourceUrl)
+      return coverUrl ? coverPersistenceService.persistCover(coverUrl) : null
+    }
   }
 }

--- a/src/test/groovy/rocks/metaldetector/butler/service/cover/CoverServiceImplTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/cover/CoverServiceImplTest.groovy
@@ -47,4 +47,15 @@ class CoverServiceImplTest extends Specification {
     and:
     !result
   }
+
+  def "if source url is null nothing is called and null returned"() {
+    when:
+    def result = underTest.transfer(null)
+
+    then:
+    0 * underTest.coverPersistenceService.persistCover(*_)
+
+    and:
+    !result
+  }
 }


### PR DESCRIPTION
The CoverService now checks the source url for null.