### PR TITLE
Refactor pagination handling

### DIFF
--- a/src/main/groovy/rocks/metaldetector/butler/model/release/ReleaseRepository.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/model/release/ReleaseRepository.groovy
@@ -28,13 +28,4 @@ interface ReleaseRepository extends JpaRepository<ReleaseEntity, Long> {
   List<ReleaseEntity> findAllByArtistInAndReleaseDateBetween(Iterable<String> artistNames, LocalDate from, LocalDate to, Sort sort)
 
   boolean existsByArtistAndAlbumTitleAndReleaseDate(String artist, String albumTitle, LocalDate releaseDate)
-
-  long countByReleaseDateAfter(LocalDate date)
-
-  long countByArtistInAndReleaseDateAfter(Iterable<String> artistNames, LocalDate date)
-
-  long countByReleaseDateBetween(LocalDate from, LocalDate to)
-
-  long countByArtistInAndReleaseDateBetween(Iterable<String> artistNames, LocalDate from, LocalDate to)
-
 }

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/PageTransformer.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/PageTransformer.groovy
@@ -1,0 +1,18 @@
+package rocks.metaldetector.butler.service.release
+
+import org.springframework.data.domain.Page
+import org.springframework.stereotype.Service
+import rocks.metaldetector.butler.web.api.Pagination
+
+@Service
+class PageTransformer {
+
+  Pagination transform(Page<?> page) {
+    return new Pagination(
+            currentPage: page.number + 1,
+            size: page.size,
+            totalPages: page.totalPages,
+            totalReleases: page.totalElements
+    )
+  }
+}

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseService.groovy
@@ -1,24 +1,20 @@
 package rocks.metaldetector.butler.service.release
 
 import rocks.metaldetector.butler.model.TimeRange
-import rocks.metaldetector.butler.web.dto.ReleaseDto
+import rocks.metaldetector.butler.web.api.ReleasesResponse
 
 import java.time.LocalDate
 
 interface ReleaseService {
 
-  List<ReleaseDto> findAllUpcomingReleases(Iterable<String> artistNames, int page, int size)
+  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames, int page, int size)
 
-  List<ReleaseDto> findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, int page, int size)
+  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, int page, int size)
 
-  List<ReleaseDto> findAllUpcomingReleases(Iterable<String> artistNames)
+  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames)
 
-  List<ReleaseDto> findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange)
+  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange)
 
-  List<ReleaseDto> findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom)
-
-  long totalCountAllUpcomingReleases(Iterable<String> artistNames)
-
-  long totalCountAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange)
+  ReleasesResponse findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom)
 
 }

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImpl.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImpl.groovy
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import rocks.metaldetector.butler.model.TimeRange
 import rocks.metaldetector.butler.model.release.ReleaseRepository
-import rocks.metaldetector.butler.web.dto.ReleaseDto
+import rocks.metaldetector.butler.web.api.ReleasesResponse
 
 import java.time.LocalDate
 
@@ -22,7 +22,7 @@ class ReleaseServiceImpl implements ReleaseService {
   ReleaseRepository releaseRepository
 
   @Autowired
-  ReleaseTransformer releaseTransformer
+  ReleasesResponseTransformer releasesResponseTransformer
 
   final Sort sorting = Sort.by(Sort.Direction.ASC, "releaseDate", "artist", "albumTitle")
 
@@ -33,99 +33,53 @@ class ReleaseServiceImpl implements ReleaseService {
 
   @Override
   @Transactional(readOnly = true)
-  List<ReleaseDto> findAllUpcomingReleases(Iterable<String> artistNames, int page, int size) {
+  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames, int page, int size) {
     PageRequest pageRequest = pageableSupplier.call(page, size)
-    if (artistNames.isEmpty()) {
-      return releaseRepository
-          .findAllByReleaseDateAfter(YESTERDAY, pageRequest)
-          .collect { releaseTransformer.transform(it) }
-    }
-    else {
-      return releaseRepository
-          .findAllByReleaseDateAfterAndArtistIn(YESTERDAY, artistNames, pageRequest)
-          .collect { releaseTransformer.transform(it) }
-    }
+    def pageResult = artistNames.isEmpty()
+            ? releaseRepository.findAllByReleaseDateAfter(YESTERDAY, pageRequest)
+            : releaseRepository.findAllByReleaseDateAfterAndArtistIn(YESTERDAY, artistNames, pageRequest)
+
+    return releasesResponseTransformer.transformPage(pageResult)
   }
 
   @Override
   @Transactional(readOnly = true)
-  List<ReleaseDto> findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, int page, int size) {
+  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, int page, int size) {
     PageRequest pageRequest = pageableSupplier.call(page, size)
-    if (artistNames.isEmpty()) {
-      return releaseRepository
-          .findAllByReleaseDateBetween(timeRange.from, timeRange.to, pageRequest)
-          .collect { releaseTransformer.transform(it) }
-    }
-    else {
-      return releaseRepository
-          .findAllByArtistInAndReleaseDateBetween(artistNames, timeRange.from, timeRange.to, pageRequest)
-          .collect { releaseTransformer.transform(it) }
-    }
+    def pageResult = artistNames.isEmpty()
+            ? releaseRepository.findAllByReleaseDateBetween(timeRange.from, timeRange.to, pageRequest)
+            : releaseRepository.findAllByArtistInAndReleaseDateBetween(artistNames, timeRange.from, timeRange.to, pageRequest)
+
+    return releasesResponseTransformer.transformPage(pageResult)
   }
 
   @Override
   @Transactional(readOnly = true)
-  List<ReleaseDto> findAllUpcomingReleases(Iterable<String> artistNames) {
-    if (artistNames.isEmpty()) {
-      return releaseRepository
-          .findAllByReleaseDateAfter(YESTERDAY, sorting)
-          .collect { releaseTransformer.transform(it) }
-    }
-    else {
-      return releaseRepository
-          .findAllByReleaseDateAfterAndArtistIn(YESTERDAY, artistNames, sorting)
-          .collect { releaseTransformer.transform(it) }
-    }
+  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames) {
+    def releaseEntities = artistNames.isEmpty()
+            ? releaseRepository.findAllByReleaseDateAfter(YESTERDAY, sorting)
+            : releaseRepository.findAllByReleaseDateAfterAndArtistIn(YESTERDAY, artistNames, sorting)
+
+    return releasesResponseTransformer.transformReleaseEntities(releaseEntities)
   }
 
   @Override
   @Transactional(readOnly = true)
-  List<ReleaseDto> findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange) {
-    if (artistNames.isEmpty()) {
-      return releaseRepository
-          .findAllByReleaseDateBetween(timeRange.from, timeRange.to, sorting)
-          .collect { releaseTransformer.transform(it) }
-    }
-    else {
-      return releaseRepository
-          .findAllByArtistInAndReleaseDateBetween(artistNames, timeRange.from, timeRange.to, sorting)
-          .collect { releaseTransformer.transform(it) }
-    }
-  }
+  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange) {
+    def releaseEntities = artistNames.isEmpty()
+            ? releaseRepository.findAllByReleaseDateBetween(timeRange.from, timeRange.to, sorting)
+            : releaseRepository.findAllByArtistInAndReleaseDateBetween(artistNames, timeRange.from, timeRange.to, sorting)
 
-  @Override
-  List<ReleaseDto> findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom) {
-    if (artistNames.isEmpty()) {
-      return releaseRepository
-              .findAllByReleaseDateAfter(dateFrom, sorting)
-              .collect { releaseTransformer.transform(it) }
-    }
-    else {
-      return releaseRepository
-              .findAllByReleaseDateAfterAndArtistIn(dateFrom, artistNames, sorting)
-              .collect { releaseTransformer.transform(it) }
-    }
+    return releasesResponseTransformer.transformReleaseEntities(releaseEntities)
   }
 
   @Override
   @Transactional(readOnly = true)
-  long totalCountAllUpcomingReleases(Iterable<String> artistNames) {
-    if (artistNames.isEmpty()) {
-      return releaseRepository.countByReleaseDateAfter(YESTERDAY)
-    }
-    else {
-      return releaseRepository.countByArtistInAndReleaseDateAfter(artistNames, YESTERDAY)
-    }
-  }
+  ReleasesResponse findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom) {
+    def releaseEntities = artistNames.isEmpty()
+            ? releaseRepository.findAllByReleaseDateAfter(dateFrom, sorting)
+            : releaseRepository.findAllByReleaseDateAfterAndArtistIn(dateFrom, artistNames, sorting)
 
-  @Override
-  @Transactional(readOnly = true)
-  long totalCountAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange) {
-    if (artistNames.isEmpty()) {
-      return releaseRepository.countByReleaseDateBetween(timeRange.from, timeRange.to)
-    }
-    else {
-      return releaseRepository.countByArtistInAndReleaseDateBetween(artistNames, timeRange.from, timeRange.to)
-    }
+    return releasesResponseTransformer.transformReleaseEntities(releaseEntities)
   }
 }

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleasesResponseTransformer.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleasesResponseTransformer.groovy
@@ -1,0 +1,35 @@
+package rocks.metaldetector.butler.service.release
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Page
+import org.springframework.stereotype.Service
+import rocks.metaldetector.butler.model.release.ReleaseEntity
+import rocks.metaldetector.butler.web.api.Pagination
+import rocks.metaldetector.butler.web.api.ReleasesResponse
+
+@Service
+class ReleasesResponseTransformer {
+
+  @Autowired
+  PageTransformer pageTransformer
+
+  @Autowired
+  ReleaseTransformer releaseTransformer
+
+  ReleasesResponse transformPage(Page<ReleaseEntity> releaseEntityPage) {
+    def pagination = pageTransformer.transform(releaseEntityPage)
+    def releases = releaseEntityPage.collect { releaseTransformer.transform(it) }
+    return new ReleasesResponse(pagination: pagination, releases: releases)
+  }
+
+  ReleasesResponse transformReleaseEntities(List<ReleaseEntity> releaseEntities) {
+    def pagination = new Pagination(
+            currentPage: 1,
+            size: releaseEntities.size(),
+            totalPages: 1,
+            totalReleases: releaseEntities.size()
+    )
+    def releases = releaseEntities.collect { releaseTransformer.transform(it) }
+    return new ReleasesResponse(pagination: pagination, releases: releases)
+  }
+}

--- a/src/main/groovy/rocks/metaldetector/butler/web/api/ErrorResponse.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/api/ErrorResponse.groovy
@@ -1,4 +1,4 @@
-package rocks.metaldetector.butler.web.dto
+package rocks.metaldetector.butler.web.api
 
 import groovy.transform.Canonical
 

--- a/src/main/groovy/rocks/metaldetector/butler/web/api/ImportJobResponse.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/api/ImportJobResponse.groovy
@@ -1,6 +1,7 @@
-package rocks.metaldetector.butler.web.dto
+package rocks.metaldetector.butler.web.api
 
 import groovy.transform.Canonical
+import rocks.metaldetector.butler.web.dto.ImportJobDto
 
 @Canonical
 class ImportJobResponse {

--- a/src/main/groovy/rocks/metaldetector/butler/web/api/Pagination.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/api/Pagination.groovy
@@ -1,0 +1,13 @@
+package rocks.metaldetector.butler.web.api
+
+import groovy.transform.Canonical
+
+@Canonical
+class Pagination {
+
+  int currentPage
+  int size
+  int totalPages
+  long totalReleases
+
+}

--- a/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesRequest.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesRequest.groovy
@@ -1,4 +1,4 @@
-package rocks.metaldetector.butler.web.dto
+package rocks.metaldetector.butler.web.api
 
 import groovy.transform.Canonical
 import org.springframework.format.annotation.DateTimeFormat

--- a/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesRequestPaginated.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesRequestPaginated.groovy
@@ -1,4 +1,4 @@
-package rocks.metaldetector.butler.web.dto
+package rocks.metaldetector.butler.web.api
 
 import groovy.transform.Canonical
 import org.springframework.format.annotation.DateTimeFormat

--- a/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesResponse.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesResponse.groovy
@@ -6,10 +6,7 @@ import rocks.metaldetector.butler.web.dto.ReleaseDto
 @Canonical
 class ReleasesResponse {
 
-  int currentPage
-  int size
-  int totalPages
-  long totalReleases
+  Pagination pagination
   Iterable<ReleaseDto> releases
 
 }

--- a/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesResponse.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesResponse.groovy
@@ -1,6 +1,7 @@
-package rocks.metaldetector.butler.web.dto
+package rocks.metaldetector.butler.web.api
 
 import groovy.transform.Canonical
+import rocks.metaldetector.butler.web.dto.ReleaseDto
 
 @Canonical
 class ReleasesResponse {

--- a/src/main/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestController.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestController.groovy
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 import rocks.metaldetector.butler.service.importjob.ImportJobService
+import rocks.metaldetector.butler.web.api.ImportJobResponse
 import rocks.metaldetector.butler.web.dto.ImportJobDto
-import rocks.metaldetector.butler.web.dto.ImportJobResponse
 
 import static rocks.metaldetector.butler.config.constants.Endpoints.COVER_JOB
 import static rocks.metaldetector.butler.config.constants.Endpoints.IMPORT_JOB

--- a/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
@@ -27,49 +27,38 @@ class ReleasesRestController {
   @PostMapping(path = RELEASES, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasRole('ROLE_USER')")
   ResponseEntity<ReleasesResponse> getPaginatedReleases(@Valid @RequestBody ReleasesRequestPaginated request) {
-    def releases
-    def totalReleases
-
+    def releasesResponse
     if (request.dateFrom == null && request.dateTo == null) {
-      totalReleases = releaseService.totalCountAllUpcomingReleases(request.artists)
-      releases = releaseService.findAllUpcomingReleases(request.artists, request.page, request.size)
+      releasesResponse = releaseService.findAllUpcomingReleases(request.artists, request.page, request.size)
     }
     else if (request.dateFrom != null && request.dateTo != null) {
       TimeRange timeRange = TimeRange.of(request.dateFrom, request.dateTo)
-      totalReleases = releaseService.totalCountAllReleasesForTimeRange(request.artists, timeRange)
-      releases = releaseService.findAllReleasesForTimeRange(request.artists, timeRange, request.page, request.size)
+      releasesResponse = releaseService.findAllReleasesForTimeRange(request.artists, timeRange, request.page, request.size)
     }
     else {
       throw new IllegalArgumentException("The parameters 'dateFrom' and 'dateTo' must both have a valid date value in the format YYYY-MM-DD.")
     }
 
-    def response = new ReleasesResponse(currentPage: request.getPage(), size: request.getSize(),
-                                        totalPages: Math.ceil(totalReleases / request.getSize()),
-                                        totalReleases: totalReleases, releases: releases)
-    return ResponseEntity.ok(response)
+    return ResponseEntity.ok(releasesResponse)
   }
 
   @PostMapping(path = RELEASES_UNPAGINATED, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasRole('ROLE_ADMINISTRATOR')")
   ResponseEntity<ReleasesResponse> getAllReleases(@Valid @RequestBody ReleasesRequest request) {
-    def releases
-
+    def releasesResponse
     if (request.dateFrom == null && request.dateTo == null) {
-      releases = releaseService.findAllUpcomingReleases(request.artists)
+      releasesResponse = releaseService.findAllUpcomingReleases(request.artists)
     }
     else if (request.dateFrom != null && request.dateTo != null) {
-      releases = releaseService.findAllReleasesForTimeRange(request.artists, TimeRange.of(request.dateFrom, request.dateTo))
+      releasesResponse = releaseService.findAllReleasesForTimeRange(request.artists, TimeRange.of(request.dateFrom, request.dateTo))
     }
     else if (request.dateFrom != null) {
-      releases = releaseService.findAllReleasesSince(request.artists, request.dateFrom)
+      releasesResponse = releaseService.findAllReleasesSince(request.artists, request.dateFrom)
     }
     else {
-      throw new IllegalArgumentException("Please specify a valid date for 'dateFrom' and 'dateTo' (YYYY-MM-DD) or only for 'dateFrom'.")
+      throw new IllegalArgumentException("Please specify a valid date for 'dateFrom' and 'dateTo' or only for 'dateFrom' with format 'YYYY-MM-DD'.")
     }
 
-    def response = new ReleasesResponse(currentPage: 1, size: releases.size(),
-                                        totalPages: 1,
-                                        totalReleases: releases.size(), releases: releases)
-    return ResponseEntity.ok(response)
+    return ResponseEntity.ok(releasesResponse)
   }
 }

--- a/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import rocks.metaldetector.butler.model.TimeRange
 import rocks.metaldetector.butler.service.release.ReleaseService
-import rocks.metaldetector.butler.web.dto.ReleasesRequest
-import rocks.metaldetector.butler.web.dto.ReleasesRequestPaginated
-import rocks.metaldetector.butler.web.dto.ReleasesResponse
+import rocks.metaldetector.butler.web.api.ReleasesRequest
+import rocks.metaldetector.butler.web.api.ReleasesRequestPaginated
+import rocks.metaldetector.butler.web.api.ReleasesResponse
 
 import javax.validation.Valid
 

--- a/src/main/groovy/rocks/metaldetector/butler/web/rest/RestExceptionHandler.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/rest/RestExceptionHandler.groovy
@@ -11,7 +11,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.context.request.WebRequest
-import rocks.metaldetector.butler.web.dto.ErrorResponse
+import rocks.metaldetector.butler.web.api.ErrorResponse
 
 import javax.validation.ValidationException
 

--- a/src/test/groovy/rocks/metaldetector/butler/DtoFactory.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/DtoFactory.groovy
@@ -15,6 +15,10 @@ class DtoFactory {
 
   static class ReleaseEntityFactory {
 
+    static ReleaseEntity createReleaseEntity(String artist) {
+      return createReleaseEntity(artist, LocalDate.now())
+    }
+
     static ReleaseEntity createReleaseEntity(String artist, LocalDate releaseDate) {
       return new ReleaseEntity(
           artist: artist,
@@ -48,6 +52,10 @@ class DtoFactory {
   }
 
   static class ReleaseDtoFactory {
+
+    static ReleaseDto createReleaseDto(String artist) {
+      return createReleaseDto(artist, LocalDate.now())
+    }
 
     static ReleaseDto createReleaseDto(String artist, LocalDate releaseDate) {
       return new ReleaseDto(

--- a/src/test/groovy/rocks/metaldetector/butler/service/importjob/MetalArchivesReleaseImporterTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/importjob/MetalArchivesReleaseImporterTest.groovy
@@ -1,12 +1,10 @@
-package rocks.metaldetector.butler.service.release
+package rocks.metaldetector.butler.service.importjob
 
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import rocks.metaldetector.butler.model.release.ReleaseEntity
 import rocks.metaldetector.butler.model.release.ReleaseRepository
 import rocks.metaldetector.butler.service.converter.MetalArchivesReleaseEntityConverter
 import rocks.metaldetector.butler.service.cover.CoverService
-import rocks.metaldetector.butler.service.importjob.ImportResult
-import rocks.metaldetector.butler.service.importjob.MetalArchivesReleaseImporter
 import rocks.metaldetector.butler.supplier.metalarchives.MetalArchivesRestClient
 import spock.lang.Specification
 import spock.lang.Unroll

--- a/src/test/groovy/rocks/metaldetector/butler/service/importjob/MetalHammerReleaseImporterTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/importjob/MetalHammerReleaseImporterTest.groovy
@@ -1,10 +1,8 @@
-package rocks.metaldetector.butler.service.release
+package rocks.metaldetector.butler.service.importjob
 
 import rocks.metaldetector.butler.model.release.ReleaseEntity
 import rocks.metaldetector.butler.model.release.ReleaseRepository
 import rocks.metaldetector.butler.service.converter.MetalHammerReleaseEntityConverter
-import rocks.metaldetector.butler.service.importjob.ImportResult
-import rocks.metaldetector.butler.service.importjob.MetalHammerReleaseImporter
 import rocks.metaldetector.butler.supplier.metalhammer.MetalHammerWebCrawler
 import spock.lang.Specification
 

--- a/src/test/groovy/rocks/metaldetector/butler/service/importjob/PersistReleaseEntityTaskTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/importjob/PersistReleaseEntityTaskTest.groovy
@@ -1,9 +1,8 @@
-package rocks.metaldetector.butler.service.release
+package rocks.metaldetector.butler.service.importjob
 
 import rocks.metaldetector.butler.model.release.ReleaseEntity
 import rocks.metaldetector.butler.model.release.ReleaseRepository
 import rocks.metaldetector.butler.service.cover.CoverService
-import rocks.metaldetector.butler.service.importjob.PersistReleaseEntityTask
 import spock.lang.Specification
 
 class PersistReleaseEntityTaskTest extends Specification {

--- a/src/test/groovy/rocks/metaldetector/butler/service/release/PageTransformerTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/release/PageTransformerTest.groovy
@@ -1,0 +1,33 @@
+package rocks.metaldetector.butler.service.release
+
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PageTransformerTest extends Specification {
+
+  PageTransformer underTest = new PageTransformer()
+
+  @Unroll
+  "should transform page to pagination"() {
+    given:
+    def pageObj = new PageImpl([], PageRequest.of(givenPage, size), total)
+
+    when:
+    def result = underTest.transform(pageObj)
+
+    then:
+    result.currentPage == expectedPage
+    result.size == size
+    result.totalPages == totalPages
+    result.totalReleases == total
+
+    where:
+    givenPage | expectedPage | size | total | totalPages
+    0         | 1            | 10   | 99    | 10
+    0         | 1            | 10   | 100   | 10
+    0         | 1            | 10   | 101   | 11
+    1         | 2            | 10   | 100   | 10
+  }
+}

--- a/src/test/groovy/rocks/metaldetector/butler/service/release/ReleasesResponseTransformerTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/release/ReleasesResponseTransformerTest.groovy
@@ -1,0 +1,126 @@
+package rocks.metaldetector.butler.service.release
+
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import rocks.metaldetector.butler.web.api.Pagination
+import spock.lang.Specification
+
+import static rocks.metaldetector.butler.DtoFactory.ReleaseEntityFactory
+import static rocks.metaldetector.butler.DtoFactory.ReleaseDtoFactory
+
+class ReleasesResponseTransformerTest extends Specification {
+
+  ReleasesResponseTransformer underTest = new ReleasesResponseTransformer(
+          pageTransformer: Mock(PageTransformer),
+          releaseTransformer: Mock(ReleaseTransformer)
+  )
+
+  def "transformPage: should call PageTransformer"() {
+    given:
+    def page = new PageImpl([], PageRequest.of(1, 10), 100)
+
+    when:
+    underTest.transformPage(page)
+
+    then:
+    1 * underTest.pageTransformer.transform(page)
+  }
+
+  def "transformPage: should return result from PageTransformer"() {
+    given:
+    def page = new PageImpl([], PageRequest.of(1, 10), 100)
+    def pagination = new Pagination(currentPage: 1)
+    underTest.pageTransformer.transform(page) >> pagination
+
+    when:
+    def result = underTest.transformPage(page)
+
+    then:
+    result.pagination == pagination
+  }
+
+  def "transformPage: should call ReleaseTransformer for each ReleaseEntity"() {
+    given:
+    def releaseEntity1 = ReleaseEntityFactory.createReleaseEntity("Karg")
+    def releaseEntity2 = ReleaseEntityFactory.createReleaseEntity("Harakiri for the sky")
+    def page = new PageImpl([releaseEntity1, releaseEntity2], PageRequest.of(1, 10), 100)
+
+    when:
+    underTest.transformPage(page)
+
+    then:
+    1 * underTest.releaseTransformer.transform(releaseEntity1)
+
+    then:
+    1 * underTest.releaseTransformer.transform(releaseEntity2)
+  }
+
+  def "transformPage: should return result from ReleaseTransformer"() {
+    given:
+    def releaseEntity1 = ReleaseEntityFactory.createReleaseEntity("Karg")
+    def releaseEntity2 = ReleaseEntityFactory.createReleaseEntity("Harakiri for the sky")
+    def releaseDto1 = ReleaseDtoFactory.createReleaseDto("Karg")
+    def releaseDto2 = ReleaseDtoFactory.createReleaseDto("Harakiri for the sky")
+    underTest.releaseTransformer.transform(releaseEntity1) >> releaseDto1
+    underTest.releaseTransformer.transform(releaseEntity2) >> releaseDto2
+    def page = new PageImpl([releaseEntity1, releaseEntity2], PageRequest.of(1, 10), 100)
+
+    when:
+    def result = underTest.transformPage(page)
+
+    then:
+    result.releases[0] == releaseDto1
+    result.releases[1] == releaseDto2
+  }
+
+  def "transformReleaseEntities: should return pagination object with one page"() {
+    given:
+    def releaseEntities = [
+            ReleaseEntityFactory.createReleaseEntity("Karg"),
+            ReleaseEntityFactory.createReleaseEntity("Harakiri for the sky")
+    ]
+
+    when:
+    def result = underTest.transformReleaseEntities(releaseEntities)
+
+    then:
+    result.pagination == new Pagination(
+            currentPage: 1,
+            size: releaseEntities.size(),
+            totalPages: 1,
+            totalReleases: releaseEntities.size()
+    )
+  }
+
+  def "transformReleaseEntities: should call ReleaseTransformer for each ReleaseEntity"() {
+    given:
+    def releaseEntity1 = ReleaseEntityFactory.createReleaseEntity("Karg")
+    def releaseEntity2 = ReleaseEntityFactory.createReleaseEntity("Harakiri for the sky")
+
+    when:
+    underTest.transformReleaseEntities([releaseEntity1, releaseEntity2])
+
+    then:
+    1 * underTest.releaseTransformer.transform(releaseEntity1)
+
+    then:
+    1 * underTest.releaseTransformer.transform(releaseEntity2)
+  }
+
+  def "transformReleaseEntities: should return result from ReleaseTransformer"() {
+    given:
+    def releaseEntity1 = ReleaseEntityFactory.createReleaseEntity("Karg")
+    def releaseEntity2 = ReleaseEntityFactory.createReleaseEntity("Harakiri for the sky")
+    def releaseDto1 = ReleaseDtoFactory.createReleaseDto("Karg")
+    def releaseDto2 = ReleaseDtoFactory.createReleaseDto("Harakiri for the sky")
+    underTest.releaseTransformer.transform(releaseEntity1) >> releaseDto1
+    underTest.releaseTransformer.transform(releaseEntity2) >> releaseDto2
+
+    when:
+    def result = underTest.transformReleaseEntities([releaseEntity1, releaseEntity2])
+
+    then:
+    result.releases[0] == releaseDto1
+    result.releases[1] == releaseDto2
+  }
+}

--- a/src/test/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestControllerTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestControllerTest.groovy
@@ -6,8 +6,8 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import rocks.metaldetector.butler.service.importjob.ImportJobService
 import rocks.metaldetector.butler.testutil.WithExceptionResolver
+import rocks.metaldetector.butler.web.api.ImportJobResponse
 import rocks.metaldetector.butler.web.dto.ImportJobDto
-import rocks.metaldetector.butler.web.dto.ImportJobResponse
 import spock.lang.Specification
 
 import static org.springframework.http.HttpStatus.OK

--- a/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerIT.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerIT.groovy
@@ -11,8 +11,8 @@ import org.springframework.test.web.servlet.MockMvc
 import rocks.metaldetector.butler.TokenFactory
 import rocks.metaldetector.butler.service.release.ReleaseService
 import rocks.metaldetector.butler.testutil.WithIntegrationTestConfig
-import rocks.metaldetector.butler.web.dto.ReleasesRequest
-import rocks.metaldetector.butler.web.dto.ReleasesRequestPaginated
+import rocks.metaldetector.butler.web.api.ReleasesRequest
+import rocks.metaldetector.butler.web.api.ReleasesRequestPaginated
 import spock.lang.Specification
 
 import static org.mockito.Mockito.reset

--- a/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerTest.groovy
@@ -8,10 +8,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import rocks.metaldetector.butler.model.TimeRange
 import rocks.metaldetector.butler.service.release.ReleaseService
 import rocks.metaldetector.butler.testutil.WithExceptionResolver
+import rocks.metaldetector.butler.web.api.Pagination
 import rocks.metaldetector.butler.web.api.ReleasesRequest
 import rocks.metaldetector.butler.web.api.ReleasesRequestPaginated
 import rocks.metaldetector.butler.web.api.ReleasesResponse
-import rocks.metaldetector.butler.web.dto.ReleaseDto
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -43,7 +43,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     objectMapper.registerModule(new JavaTimeModule())
   }
 
-  def "Requesting unpaginated releases endpoint with valid request should call releases service"() {
+  def "getAllReleases: should call releases service if no time range is given"() {
     given:
     def artists = [ARTIST_NAME]
     def releasesRequest = new ReleasesRequest(artists: artists)
@@ -56,17 +56,16 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     mockMvc.perform(request).andReturn()
 
     then:
-    1 * underTest.releaseService.findAllUpcomingReleases(artists) >> []
+    1 * underTest.releaseService.findAllUpcomingReleases(artists)
   }
 
-  def "Requesting unpaginated releases endpoint with valid request should return ok"() {
+  def "getAllReleases: should return ok if no time range is given"() {
     given:
     def releasesRequest = new ReleasesRequest(artists: [ARTIST_NAME])
     def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
-    underTest.releaseService.findAllUpcomingReleases(_) >> getReleaseDtos()
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -75,26 +74,25 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     result.response.status == OK.value()
   }
 
-  def "Requesting unpaginated releases endpoint with valid request should return releases"() {
+  def "getAllReleases: should return result from release service if no time range is given"() {
     given:
-    def expectedReleases = getReleaseDtos()
+    def expectedReleasesReponse = createReleasesReponse()
     def releasesRequest = new ReleasesRequest(artists: [ARTIST_NAME])
     def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
-    underTest.releaseService.findAllUpcomingReleases(_) >> expectedReleases
+    underTest.releaseService.findAllUpcomingReleases(_) >> expectedReleasesReponse
 
     when:
     def result = mockMvc.perform(request).andReturn()
 
     then:
     ReleasesResponse releasesResponse = objectMapper.readValue(result.response.getContentAsString(), ReleasesResponse)
-    releasesResponse.releases.size() == 2
-    releasesResponse.releases == expectedReleases
+    releasesResponse == expectedReleasesReponse
   }
 
-  def "Requesting unpaginated releases endpoint with valid request with time range should call releases service"() {
+  def "getAllReleases: should call releases service if time range is given"() {
     given:
     def from = LocalDate.of(2020, 1, 1)
     def to = LocalDate.of(2020, 2, 1)
@@ -109,21 +107,16 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     mockMvc.perform(request).andReturn()
 
     then:
-    1 * underTest.releaseService.findAllReleasesForTimeRange(artists, TimeRange.of(from, to)) >> []
+    1 * underTest.releaseService.findAllReleasesForTimeRange(artists, TimeRange.of(from, to))
   }
 
-  def "Requesting unpaginated releases endpoint with valid request with time range should return ok"() {
+  def "getAllReleases: should return ok if time range is given"() {
     given:
-    def from = LocalDate.of(2020, 1, 1)
-    def to = LocalDate.of(2020, 2, 1)
-    def artists = [ARTIST_NAME]
-    def requestDto = new ReleasesRequest(artists: artists, dateFrom: from, dateTo: to)
-    def expectedReleases = [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31))]
+    def requestDto = new ReleasesRequest(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1), dateTo: LocalDate.of(2020, 2, 1))
     def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto))
-    underTest.releaseService.findAllReleasesForTimeRange(*_) >> expectedReleases
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -132,28 +125,25 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     result.response.status == OK.value()
   }
 
-  def "Requesting unpaginated releases endpoint with valid request with time range should return releases"() {
+  def "getAllReleases: should return result from release service if time range is given"() {
     given:
-    def from = LocalDate.of(2020, 1, 1)
-    def to = LocalDate.of(2020, 2, 1)
-    def artists = [ARTIST_NAME]
-    def requestDto = new ReleasesRequest(artists: artists, dateFrom: from, dateTo: to)
-    def expectedReleases = [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31))]
+    def requestDto = new ReleasesRequest(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1), dateTo: LocalDate.of(2020, 2, 1))
+    def expectedReleasesResponse = createReleasesReponse()
     def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto))
-    underTest.releaseService.findAllReleasesForTimeRange(artists, TimeRange.of(from, to)) >> expectedReleases
+    underTest.releaseService.findAllReleasesForTimeRange(*_) >> expectedReleasesResponse
 
     when:
     def result = mockMvc.perform(request).andReturn()
 
     then:
     ReleasesResponse releasesResponse = objectMapper.readValue(result.response.getContentAsString(), ReleasesResponse)
-    releasesResponse.releases == expectedReleases
+    releasesResponse == expectedReleasesResponse
   }
 
-  def "Requesting unpaginated releases endpoint with valid request with only 'dateFrom' should call releases service"() {
+  def "getAllReleases: should call releases service if only 'dateFrom' is given"() {
     given:
     def from = LocalDate.of(2020, 1, 1)
     def artists = [ARTIST_NAME]
@@ -170,17 +160,13 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     1 * underTest.releaseService.findAllReleasesSince(artists, from) >> []
   }
 
-  def "Requesting unpaginated releases endpoint with valid request with only 'dateFrom' should return ok"() {
+  def "getAllReleases: should return ok if only 'dateFrom' is given"() {
     given:
-    def from = LocalDate.of(2020, 1, 1)
-    def artists = [ARTIST_NAME]
-    def requestDto = new ReleasesRequest(artists: artists, dateFrom: from)
-    def expectedReleases = [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31))]
+    def requestDto = new ReleasesRequest(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1))
     def request = post(RELEASES_UNPAGINATED)
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(requestDto))
-    underTest.releaseService.findAllReleasesSince(*_) >> expectedReleases
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -189,28 +175,26 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     result.response.status == OK.value()
   }
 
-  def "Requesting unpaginated releases endpoint with valid request with only 'dateFrom' should return releases"() {
+  def "getAllReleases: should return result from release service if only 'dateFrom' is given"() {
     given:
-    def from = LocalDate.of(2020, 1, 1)
-    def artists = [ARTIST_NAME]
-    def requestDto = new ReleasesRequest(artists: artists, dateFrom: from)
-    def expectedReleases = [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31))]
+    def requestDto = new ReleasesRequest(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1))
+    def expectedReleasesResponse = createReleasesReponse()
     def request = post(RELEASES_UNPAGINATED)
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(requestDto))
-    underTest.releaseService.findAllReleasesSince(*_) >> expectedReleases
+    underTest.releaseService.findAllReleasesSince(*_) >> expectedReleasesResponse
 
     when:
     def result = mockMvc.perform(request).andReturn()
 
     then:
     ReleasesResponse releasesResponse = objectMapper.readValue(result.response.getContentAsString(), ReleasesResponse)
-    releasesResponse.releases == expectedReleases
+    releasesResponse == expectedReleasesResponse
   }
 
   @Unroll
-  "Requesting unpaginated releases with bad request should not call releases service"() {
+  "getAllReleases: bad request should not call releases service"() {
     given:
     def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
@@ -231,7 +215,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
   }
 
   @Unroll
-  "Requesting unpaginated releases with bad request should return bad request"() {
+  "getAllReleases: bad request should return status bad request"() {
     given:
     def request = post(RELEASES_UNPAGINATED)
         .contentType(MediaType.APPLICATION_JSON)
@@ -250,7 +234,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
              new ReleasesRequest(artists: [ARTIST_NAME], dateFrom: null, dateTo: LocalDate.of(2020, 2, 1))]
   }
 
-  def "Requesting releases endpoint with valid request should call releases service"() {
+  def "getPaginatedReleases: valid request without time range should call releases service"() {
     given:
     def artists = [ARTIST_NAME]
     def releasesRequest = new ReleasesRequestPaginated(artists: artists, page: 1, size: 10)
@@ -264,20 +248,15 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
 
     then:
     1 * underTest.releaseService.findAllUpcomingReleases(releasesRequest.artists, releasesRequest.page, releasesRequest.size)
-
-    and:
-    1 * underTest.releaseService.totalCountAllUpcomingReleases(releasesRequest.artists)
   }
 
-  def "Requesting releases endpoint with valid request should return ok"() {
+  def "getPaginatedReleases: valid request without time range should return ok"() {
     given:
-    def expectedReleases = getReleaseDtos()
     def releasesRequest = new ReleasesRequestPaginated(artists: [ARTIST_NAME], page: 1, size: 10)
     def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
-    underTest.releaseService.findAllUpcomingReleases(*_) >> expectedReleases
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -286,67 +265,25 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     result.response.status == OK.value()
   }
 
-  def "Requesting releases endpoint with valid request should return releases"() {
+  def "getPaginatedReleases: valid request without time range should return releases"() {
     given:
-    def expectedReleases = getReleaseDtos()
+    def expectedReleasesResponse = createReleasesReponse()
     def releasesRequest = new ReleasesRequestPaginated(artists: [ARTIST_NAME], page: 1, size: 10)
     def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
-    underTest.releaseService.findAllUpcomingReleases(*_) >> expectedReleases
-    underTest.releaseService.totalCountAllUpcomingReleases(releasesRequest.artists) >> expectedReleases.size()
+    underTest.releaseService.findAllUpcomingReleases(*_) >> expectedReleasesResponse
 
     when:
     def result = mockMvc.perform(request).andReturn()
 
     then:
     ReleasesResponse releasesResponse = objectMapper.readValue(result.response.getContentAsString(), ReleasesResponse)
-    releasesResponse.releases.size() == 2
-    releasesResponse.releases == expectedReleases
+    releasesResponse == expectedReleasesResponse
   }
 
-  def "Requesting releases endpoint with valid request should return requested pagination"() {
-    given:
-    def expectedReleases = getReleaseDtos()
-    def releasesRequest = new ReleasesRequestPaginated(artists: [ARTIST_NAME], page: 1, size: 10)
-    def request = post(RELEASES)
-        .contentType(MediaType.APPLICATION_JSON)
-        .accept(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(releasesRequest))
-    underTest.releaseService.findAllUpcomingReleases(*_) >> expectedReleases
-
-    when:
-    def result = mockMvc.perform(request).andReturn()
-
-    then:
-    ReleasesResponse releasesResponse = objectMapper.readValue(result.response.getContentAsString(), ReleasesResponse)
-    releasesResponse.currentPage == releasesRequest.page
-    releasesResponse.size == releasesRequest.size
-  }
-
-  def "Total pages are calculates correctly"() {
-    given:
-    def expectedPages = 3
-    def expectedReleases = getReleaseDtosForPaginationTest()
-    def releasesRequest = new ReleasesRequestPaginated(artists: [ARTIST_NAME], page: 1, size: 2)
-    def request = post(RELEASES)
-        .contentType(MediaType.APPLICATION_JSON)
-        .accept(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(releasesRequest))
-    underTest.releaseService.findAllUpcomingReleases(*_) >> expectedReleases
-    underTest.releaseService.totalCountAllUpcomingReleases(_) >> expectedReleases.size()
-
-    when:
-    def result = mockMvc.perform(request).andReturn()
-
-    then:
-    ReleasesResponse releasesResponse = objectMapper.readValue(result.response.getContentAsString(), ReleasesResponse)
-    releasesResponse.totalReleases == expectedReleases.size()
-    releasesResponse.totalPages == expectedPages
-  }
-
-  def "Requesting releases endpoint with valid request with time range should call releases service"() {
+  def "getPaginatedReleases: valid request with time range should call releases service"() {
     given:
     def from = LocalDate.of(2020, 1, 1)
     def to = LocalDate.of(2020, 2, 1)
@@ -362,23 +299,15 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
 
     then:
     1 * underTest.releaseService.findAllReleasesForTimeRange(artists, TimeRange.of(from, to), requestDto.page, requestDto.size)
-
-    and:
-    1 * underTest.releaseService.totalCountAllReleasesForTimeRange(artists, TimeRange.of(from, to))
   }
 
-  def "Requesting releases endpoint with valid request with time range should return ok"() {
+  def "getPaginatedReleases: valid request with time range should return ok"() {
     given:
-    def from = LocalDate.of(2020, 1, 1)
-    def to = LocalDate.of(2020, 2, 1)
-    def artists = [ARTIST_NAME]
-    def requestDto = new ReleasesRequestPaginated(artists: artists, dateFrom: from, dateTo: to, page: 1, size: 10)
-    def expectedReleases = [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31))]
+    def requestDto = new ReleasesRequestPaginated(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1), dateTo: LocalDate.of(2020, 2, 1), page: 1, size: 10)
     def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto))
-    underTest.releaseService.findAllReleasesForTimeRange(*_) >> expectedReleases
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -387,29 +316,26 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     result.response.status == OK.value()
   }
 
-  def "Requesting releases endpoint with valid request with time range should return releases"() {
+  def "getPaginatedReleases: valid request with time range should return releases"() {
     given:
-    def from = LocalDate.of(2020, 1, 1)
-    def to = LocalDate.of(2020, 2, 1)
-    def artists = [ARTIST_NAME]
-    def requestDto = new ReleasesRequestPaginated(artists: artists, dateFrom: from, dateTo: to, page: 1, size: 10)
-    def expectedReleases = [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31))]
+    def requestDto = new ReleasesRequestPaginated(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1), dateTo: LocalDate.of(2020, 2, 1), page: 1, size: 10)
+    def expectedReleasesResponse = createReleasesReponse()
     def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto))
-    underTest.releaseService.findAllReleasesForTimeRange(*_) >> expectedReleases
+    underTest.releaseService.findAllReleasesForTimeRange(*_) >> expectedReleasesResponse
 
     when:
     def result = mockMvc.perform(request).andReturn()
 
     then:
     ReleasesResponse releasesResponse = objectMapper.readValue(result.response.getContentAsString(), ReleasesResponse)
-    releasesResponse.releases == expectedReleases
+    releasesResponse == expectedReleasesResponse
   }
 
   @Unroll
-  "Requesting releases with bad request should return bad request"() {
+  "getPaginatedReleases: bad request should return status bad request"() {
     given:
     def request = post(RELEASES)
         .contentType(MediaType.APPLICATION_JSON)
@@ -442,16 +368,18 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
                                           page: 1, size: 10)]
   }
 
-  private static List<ReleaseDto> getReleaseDtos() {
-    return [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31)),
-            ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 2, 28))]
-  }
-
-  private static List<ReleaseDto> getReleaseDtosForPaginationTest() {
-    return [ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31)),
-            ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 2, 28)),
-            ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 3, 31)),
-            ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 4, 28)),
-            ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 5, 28))]
+  private static ReleasesResponse createReleasesReponse() {
+    return new ReleasesResponse(
+            pagination: new Pagination(
+                    currentPage: 1,
+                    size: 10,
+                    totalReleases: 2,
+                    totalPages: 1
+            ),
+            releases: [
+                    ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 1, 31)),
+                    ReleaseDtoFactory.createReleaseDto(ARTIST_NAME, LocalDate.of(2020, 2, 28))
+            ]
+    )
   }
 }

--- a/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerTest.groovy
@@ -8,10 +8,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import rocks.metaldetector.butler.model.TimeRange
 import rocks.metaldetector.butler.service.release.ReleaseService
 import rocks.metaldetector.butler.testutil.WithExceptionResolver
+import rocks.metaldetector.butler.web.api.ReleasesRequest
+import rocks.metaldetector.butler.web.api.ReleasesRequestPaginated
+import rocks.metaldetector.butler.web.api.ReleasesResponse
 import rocks.metaldetector.butler.web.dto.ReleaseDto
-import rocks.metaldetector.butler.web.dto.ReleasesRequest
-import rocks.metaldetector.butler.web.dto.ReleasesRequestPaginated
-import rocks.metaldetector.butler.web.dto.ReleasesResponse
 import spock.lang.Specification
 import spock.lang.Unroll
 


### PR DESCRIPTION
We already got one `Page` back from the Spring Data Repository. The `Page` contains all relevant pagination information. Therefore I removed the `countXXX` methods and did some other refactorings.