### PR TITLE
Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  id 'org.springframework.boot' version '2.3.2.RELEASE'
-  id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+  id 'org.springframework.boot' version '2.3.4.RELEASE'
+  id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'groovy'
   id 'jacoco'
 }
@@ -16,13 +16,13 @@ springBoot {
 
 def swaggerVersion = '3.0.0'
 def spockVersion = '2.0-M3-groovy-3.0'
-def groovyVersion = '3.0.5'
-def postgresqlVersion = '42.2.14'
+def groovyVersion = '3.0.6'
+def postgresqlVersion = '42.2.18'
 def bucket4JVersion = '0.2.0'
 def jsonwebtokenVersion = '0.9.1'
 def httpBuilderVersion = '0.7.1'
-def commonsIoVersion = '2.7'
-def awsS3SdkVersion = '1.11.826'
+def commonsIoVersion = '2.8.0'
+def awsS3SdkVersion = '1.11.881'
 
 configurations {
   developmentOnly
@@ -49,7 +49,9 @@ dependencies {
   implementation "org.ehcache:ehcache"
   implementation "com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:$bucket4JVersion"
 
-  implementation "org.codehaus.groovy:groovy-all:$groovyVersion" exclude group: "org.codehaus.groovy", module: "groovy-testng"
+  implementation "org.codehaus.groovy:groovy:$groovyVersion"
+  implementation "org.codehaus.groovy:groovy-xml:$groovyVersion"
+  implementation "org.codehaus.groovy:groovy-datetime:$groovyVersion"
 
   implementation "org.codehaus.groovy.modules.http-builder:http-builder:$httpBuilderVersion"
   implementation "commons-io:commons-io:$commonsIoVersion"
@@ -66,6 +68,7 @@ dependencies {
   testImplementation("org.springframework.boot:spring-boot-starter-test") {
     exclude group: 'junit', module: 'junit'
   }
+  testImplementation "org.codehaus.groovy:groovy-test:$groovyVersion"
   testImplementation "org.spockframework:spock-core:$spockVersion"
   testImplementation "org.spockframework:spock-spring:$spockVersion"
   testImplementation "org.springframework.security:spring-security-test"


### PR DESCRIPTION
I did some dependency updates and replaced groovy-all with the modules we actually need. groovy-all pulls groovy-test transitively which is unnecessary in production.