### PR TITLE
Sorting for releases endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN mkdir /app
 WORKDIR /app
 
 RUN useradd --no-log-init --no-create-home --shell /bin/false service_user
+USER service_user
 
 # Arguments
 ARG SOURCE_JAR_FILE="build/libs/*.jar"

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseService.groovy
@@ -1,5 +1,6 @@
 package rocks.metaldetector.butler.service.release
 
+import org.springframework.data.domain.Sort
 import rocks.metaldetector.butler.model.TimeRange
 import rocks.metaldetector.butler.model.release.ReleaseEntityState
 import rocks.metaldetector.butler.web.api.ReleasesResponse
@@ -8,17 +9,17 @@ import java.time.LocalDate
 
 interface ReleaseService {
 
-  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames, int page, int size)
+  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames, int page, int size, Sort sorting)
 
-  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, int page, int size)
+  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, int page, int size, Sort sorting)
 
-  ReleasesResponse findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom, int page, int size)
+  ReleasesResponse findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom, int page, int size, Sort sorting)
 
-  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames)
+  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames, Sort sorting)
 
-  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange)
+  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, Sort sorting)
 
-  ReleasesResponse findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom)
+  ReleasesResponse findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom, Sort sorting)
 
   void updateReleaseState(long releaseId, ReleaseEntityState state)
 

--- a/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImpl.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImpl.groovy
@@ -25,17 +25,15 @@ class ReleaseServiceImpl implements ReleaseService {
   @Autowired
   ReleasesResponseTransformer releasesResponseTransformer
 
-  final Sort sorting = Sort.by(Sort.Direction.ASC, "releaseDate", "artist", "albumTitle")
-
-  final Closure<PageRequest> pageableSupplier = { int page, int size ->
+  final Closure<PageRequest> pageableSupplier = { int page, int size, Sort sorting ->
     // Since the page is index-based we decrement the value by 1
     return PageRequest.of(page - 1, size, sorting)
   }
 
   @Override
   @Transactional(readOnly = true)
-  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames, int page, int size) {
-    PageRequest pageRequest = pageableSupplier.call(page, size)
+  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames, int page, int size, Sort sorting) {
+    PageRequest pageRequest = pageableSupplier.call(page, size, sorting)
     def pageResult = artistNames.isEmpty()
         ? releaseRepository.findAllByReleaseDateAfterAndState(YESTERDAY, ReleaseEntityState.OK, pageRequest)
         : releaseRepository.findAllByReleaseDateAfterAndArtistInAndState(YESTERDAY, artistNames, ReleaseEntityState.OK, pageRequest)
@@ -45,8 +43,8 @@ class ReleaseServiceImpl implements ReleaseService {
 
   @Override
   @Transactional(readOnly = true)
-  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, int page, int size) {
-    PageRequest pageRequest = pageableSupplier.call(page, size)
+  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, int page, int size, Sort sorting) {
+    PageRequest pageRequest = pageableSupplier.call(page, size, sorting)
     def pageResult = artistNames.isEmpty()
         ? releaseRepository.findAllByReleaseDateBetweenAndState(timeRange.from, timeRange.to, ReleaseEntityState.OK, pageRequest)
         : releaseRepository.findAllByArtistInAndReleaseDateBetweenAndState(artistNames, timeRange.from, timeRange.to, ReleaseEntityState.OK, pageRequest)
@@ -56,8 +54,8 @@ class ReleaseServiceImpl implements ReleaseService {
 
   @Override
   @Transactional(readOnly = true)
-  ReleasesResponse findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom, int page, int size) {
-    PageRequest pageRequest = pageableSupplier.call(page, size)
+  ReleasesResponse findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom, int page, int size, Sort sorting) {
+    PageRequest pageRequest = pageableSupplier.call(page, size, sorting)
     def pageResult = artistNames.isEmpty()
         ? releaseRepository.findAllByReleaseDateAfterAndState(dateFrom, ReleaseEntityState.OK, pageRequest)
         : releaseRepository.findAllByReleaseDateAfterAndArtistInAndState(dateFrom, artistNames, ReleaseEntityState.OK, pageRequest)
@@ -67,7 +65,7 @@ class ReleaseServiceImpl implements ReleaseService {
 
   @Override
   @Transactional(readOnly = true)
-  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames) {
+  ReleasesResponse findAllUpcomingReleases(Iterable<String> artistNames, Sort sorting) {
     def releaseEntities = artistNames.isEmpty()
         ? releaseRepository.findAllByReleaseDateAfter(YESTERDAY, sorting)
         : releaseRepository.findAllByReleaseDateAfterAndArtistIn(YESTERDAY, artistNames, sorting)
@@ -77,7 +75,7 @@ class ReleaseServiceImpl implements ReleaseService {
 
   @Override
   @Transactional(readOnly = true)
-  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange) {
+  ReleasesResponse findAllReleasesForTimeRange(Iterable<String> artistNames, TimeRange timeRange, Sort sorting) {
     def releaseEntities = artistNames.isEmpty()
         ? releaseRepository.findAllByReleaseDateBetween(timeRange.from, timeRange.to, sorting)
         : releaseRepository.findAllByArtistInAndReleaseDateBetween(artistNames, timeRange.from, timeRange.to, sorting)
@@ -87,7 +85,7 @@ class ReleaseServiceImpl implements ReleaseService {
 
   @Override
   @Transactional(readOnly = true)
-  ReleasesResponse findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom) {
+  ReleasesResponse findAllReleasesSince(Iterable<String> artistNames, LocalDate dateFrom, Sort sorting) {
     def releaseEntities = artistNames.isEmpty()
         ? releaseRepository.findAllByReleaseDateAfter(dateFrom, sorting)
         : releaseRepository.findAllByReleaseDateAfterAndArtistIn(dateFrom, artistNames, sorting)

--- a/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
@@ -1,6 +1,8 @@
 package rocks.metaldetector.butler.web.rest
 
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.SortDefault
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -19,6 +21,7 @@ import rocks.metaldetector.butler.web.api.ReleasesResponse
 
 import javax.validation.Valid
 
+import static org.springframework.data.domain.Sort.Direction.ASC
 import static rocks.metaldetector.butler.config.constants.Endpoints.RELEASES
 import static rocks.metaldetector.butler.config.constants.Endpoints.RELEASES_UNPAGINATED
 
@@ -30,17 +33,18 @@ class ReleasesRestController {
 
   @PostMapping(path = RELEASES, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasRole('ROLE_USER')")
-  ResponseEntity<ReleasesResponse> getPaginatedReleases(@Valid @RequestBody ReleasesRequestPaginated request) {
+  ResponseEntity<ReleasesResponse> getPaginatedReleases(@Valid @RequestBody ReleasesRequestPaginated request,
+                                                        @SortDefault(sort =["releaseDate", "artist", "albumTitle"], direction=ASC) Sort sorting) {
     def releasesResponse
     if (request.dateFrom == null && request.dateTo == null) {
-      releasesResponse = releaseService.findAllUpcomingReleases(request.artists, request.page, request.size)
+      releasesResponse = releaseService.findAllUpcomingReleases(request.artists, request.page, request.size, sorting)
     }
     else if (request.dateFrom != null && request.dateTo != null) {
       TimeRange timeRange = TimeRange.of(request.dateFrom, request.dateTo)
-      releasesResponse = releaseService.findAllReleasesForTimeRange(request.artists, timeRange, request.page, request.size)
+      releasesResponse = releaseService.findAllReleasesForTimeRange(request.artists, timeRange, request.page, request.size, sorting)
     }
     else if (request.dateFrom != null) {
-      releasesResponse = releaseService.findAllReleasesSince(request.artists, request.dateFrom, request.page, request.size)
+      releasesResponse = releaseService.findAllReleasesSince(request.artists, request.dateFrom, request.page, request.size, sorting)
     }
     else {
       throw new IllegalArgumentException("Please specify a valid date for 'dateFrom' and 'dateTo' or only for 'dateFrom' with format 'YYYY-MM-DD'.")
@@ -51,16 +55,17 @@ class ReleasesRestController {
 
   @PostMapping(path = RELEASES_UNPAGINATED, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasRole('ROLE_ADMINISTRATOR')")
-  ResponseEntity<ReleasesResponse> getAllReleases(@Valid @RequestBody ReleasesRequest request) {
+  ResponseEntity<ReleasesResponse> getAllReleases(@Valid @RequestBody ReleasesRequest request,
+                                                  @SortDefault(sort =["releaseDate", "artist", "albumTitle"], direction=ASC) Sort sorting) {
     def releasesResponse
     if (request.dateFrom == null && request.dateTo == null) {
-      releasesResponse = releaseService.findAllUpcomingReleases(request.artists)
+      releasesResponse = releaseService.findAllUpcomingReleases(request.artists, sorting)
     }
     else if (request.dateFrom != null && request.dateTo != null) {
-      releasesResponse = releaseService.findAllReleasesForTimeRange(request.artists, TimeRange.of(request.dateFrom, request.dateTo))
+      releasesResponse = releaseService.findAllReleasesForTimeRange(request.artists, TimeRange.of(request.dateFrom, request.dateTo), sorting)
     }
     else if (request.dateFrom != null) {
-      releasesResponse = releaseService.findAllReleasesSince(request.artists, request.dateFrom)
+      releasesResponse = releaseService.findAllReleasesSince(request.artists, request.dateFrom, sorting)
     }
     else {
       throw new IllegalArgumentException("Please specify a valid date for 'dateFrom' and 'dateTo' or only for 'dateFrom' with format 'YYYY-MM-DD'.")

--- a/src/test/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImplTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImplTest.groovy
@@ -11,6 +11,7 @@ import spock.lang.Specification
 
 import java.time.LocalDate
 
+import static org.springframework.data.domain.Sort.Direction.DESC
 import static rocks.metaldetector.butler.DtoFactory.ReleaseEntityFactory
 import static rocks.metaldetector.butler.model.release.ReleaseEntityState.FAULTY
 import static rocks.metaldetector.butler.model.release.ReleaseEntityState.OK
@@ -23,7 +24,7 @@ class ReleaseServiceImplTest extends Specification {
   )
 
   static final LocalDate NOW = LocalDate.now()
-  static final Sort sorting = Sort.by(Sort.Direction.ASC, "releaseDate", "artist", "albumTitle")
+  static final Sort sorting = Sort.by(DESC, "releaseDate", "artist", "albumTitle")
   static final ReleasesResponse response = new ReleasesResponse()
   static final ReleaseEntityState state = OK
 
@@ -34,7 +35,7 @@ class ReleaseServiceImplTest extends Specification {
     def expectedPageRequest = PageRequest.of(page - 1, size, sorting)
 
     when:
-    underTest.findAllUpcomingReleases([], page, size)
+    underTest.findAllUpcomingReleases([], page, size, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByReleaseDateAfterAndState(NOW - 1, state, expectedPageRequest)
@@ -49,7 +50,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByReleaseDateAfterAndState(*_) >> pageResult
 
     when:
-    def result = underTest.findAllUpcomingReleases([], 1, 10)
+    def result = underTest.findAllUpcomingReleases([], 1, 10, sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformPage(pageResult) >> response
@@ -66,7 +67,7 @@ class ReleaseServiceImplTest extends Specification {
     def expectedPageRequest = PageRequest.of(page - 1, size, sorting)
 
     when:
-    underTest.findAllUpcomingReleases(artistNames, page, size)
+    underTest.findAllUpcomingReleases(artistNames, page, size, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByReleaseDateAfterAndArtistInAndState(NOW - 1, artistNames, state, expectedPageRequest)
@@ -81,7 +82,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByReleaseDateAfterAndArtistInAndState(*_) >> pageResult
 
     when:
-    def result = underTest.findAllUpcomingReleases(["A1"], 1, 10)
+    def result = underTest.findAllUpcomingReleases(["A1"], 1, 10, sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformPage(pageResult) >> response
@@ -98,7 +99,7 @@ class ReleaseServiceImplTest extends Specification {
     def expectedPageRequest = PageRequest.of(page - 1, size, sorting)
 
     when:
-    underTest.findAllReleasesForTimeRange([], timeRange, page, size)
+    underTest.findAllReleasesForTimeRange([], timeRange, page, size, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByReleaseDateBetweenAndState(timeRange.from, timeRange.to, state, expectedPageRequest)
@@ -113,7 +114,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByReleaseDateBetweenAndState(*_) >> pageResult
 
     when:
-    def result = underTest.findAllReleasesForTimeRange([], TimeRange.of(LocalDate.now() - 1, LocalDate.now()), 1, 10)
+    def result = underTest.findAllReleasesForTimeRange([], TimeRange.of(LocalDate.now() - 1, LocalDate.now()), 1, 10, sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformPage(pageResult) >> response
@@ -131,7 +132,7 @@ class ReleaseServiceImplTest extends Specification {
     def expectedPageRequest = PageRequest.of(page - 1, size, sorting)
 
     when:
-    underTest.findAllReleasesForTimeRange(artistNames, timeRange, page, size)
+    underTest.findAllReleasesForTimeRange(artistNames, timeRange, page, size, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByArtistInAndReleaseDateBetweenAndState(artistNames, timeRange.from, timeRange.to, state, expectedPageRequest)
@@ -146,7 +147,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByArtistInAndReleaseDateBetweenAndState(*_) >> pageResult
 
     when:
-    def result = underTest.findAllReleasesForTimeRange(["A1"], TimeRange.of(LocalDate.now() - 1, LocalDate.now()), 1, 10)
+    def result = underTest.findAllReleasesForTimeRange(["A1"], TimeRange.of(LocalDate.now() - 1, LocalDate.now()), 1, 10, sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformPage(pageResult) >> response
@@ -163,7 +164,7 @@ class ReleaseServiceImplTest extends Specification {
     def expectedPageRequest = PageRequest.of(page - 1, size, sorting)
 
     when:
-    underTest.findAllReleasesSince([], date, page, size)
+    underTest.findAllReleasesSince([], date, page, size, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByReleaseDateAfterAndState(date, state, expectedPageRequest)
@@ -178,7 +179,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByReleaseDateAfterAndState(*_) >> pageResult
 
     when:
-    def result = underTest.findAllReleasesSince([], LocalDate.now(), 1, 10)
+    def result = underTest.findAllReleasesSince([], LocalDate.now(), 1, 10, sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformPage(pageResult) >> response
@@ -196,7 +197,7 @@ class ReleaseServiceImplTest extends Specification {
     def expectedPageRequest = PageRequest.of(page - 1, size, sorting)
 
     when:
-    underTest.findAllReleasesSince(artists, date, page, size)
+    underTest.findAllReleasesSince(artists, date, page, size, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByReleaseDateAfterAndArtistInAndState(date, artists, state, expectedPageRequest)
@@ -211,7 +212,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByReleaseDateAfterAndArtistInAndState(*_) >> pageResult
 
     when:
-    def result = underTest.findAllReleasesSince(["A1"], LocalDate.now(), 1, 10)
+    def result = underTest.findAllReleasesSince(["A1"], LocalDate.now(), 1, 10, sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformPage(pageResult) >> response
@@ -222,7 +223,7 @@ class ReleaseServiceImplTest extends Specification {
 
   def "findAllUpcomingReleases: should request all upcoming releases from release repository if no artist names are given"() {
     when:
-    underTest.findAllUpcomingReleases([])
+    underTest.findAllUpcomingReleases([], sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByReleaseDateAfter(NOW - 1, sorting)
@@ -235,7 +236,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByReleaseDateAfter(*_) >> releaseEntities
 
     when:
-    def result = underTest.findAllUpcomingReleases([])
+    def result = underTest.findAllUpcomingReleases([], sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformReleaseEntities(releaseEntities) >> response
@@ -249,7 +250,7 @@ class ReleaseServiceImplTest extends Specification {
     def artistNames = ["A1"]
 
     when:
-    underTest.findAllUpcomingReleases(artistNames)
+    underTest.findAllUpcomingReleases(artistNames, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByReleaseDateAfterAndArtistIn(NOW - 1, artistNames, sorting)
@@ -262,7 +263,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByReleaseDateAfterAndArtistIn(*_) >> releaseEntities
 
     when:
-    def result = underTest.findAllUpcomingReleases(["A1"])
+    def result = underTest.findAllUpcomingReleases(["A1"], sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformReleaseEntities(releaseEntities) >> response
@@ -276,7 +277,7 @@ class ReleaseServiceImplTest extends Specification {
     def timeRange = TimeRange.of(LocalDate.now() - 1, LocalDate.now())
 
     when:
-    underTest.findAllReleasesForTimeRange([], timeRange)
+    underTest.findAllReleasesForTimeRange([], timeRange, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByReleaseDateBetween(timeRange.from, timeRange.to, sorting)
@@ -289,7 +290,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByReleaseDateBetween(*_) >> releaseEntities
 
     when:
-    def result = underTest.findAllReleasesForTimeRange([], TimeRange.of(LocalDate.now() - 1, LocalDate.now()))
+    def result = underTest.findAllReleasesForTimeRange([], TimeRange.of(LocalDate.now() - 1, LocalDate.now()), sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformReleaseEntities(releaseEntities) >> response
@@ -304,7 +305,7 @@ class ReleaseServiceImplTest extends Specification {
     def timeRange = TimeRange.of(LocalDate.now() - 1, LocalDate.now())
 
     when:
-    underTest.findAllReleasesForTimeRange(artistNames, timeRange)
+    underTest.findAllReleasesForTimeRange(artistNames, timeRange, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByArtistInAndReleaseDateBetween(artistNames, timeRange.from, timeRange.to, sorting)
@@ -317,7 +318,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByArtistInAndReleaseDateBetween(*_) >> releaseEntities
 
     when:
-    def result = underTest.findAllReleasesForTimeRange(["A1"], TimeRange.of(LocalDate.now() - 1, LocalDate.now()))
+    def result = underTest.findAllReleasesForTimeRange(["A1"], TimeRange.of(LocalDate.now() - 1, LocalDate.now()), sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformReleaseEntities(releaseEntities) >> response
@@ -331,7 +332,7 @@ class ReleaseServiceImplTest extends Specification {
     def date = LocalDate.now()
 
     when:
-    underTest.findAllReleasesSince([], date)
+    underTest.findAllReleasesSince([], date, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByReleaseDateAfter(date, sorting)
@@ -344,7 +345,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByReleaseDateAfter(*_) >> releaseEntities
 
     when:
-    def result = underTest.findAllReleasesSince([], LocalDate.now())
+    def result = underTest.findAllReleasesSince([], LocalDate.now(), sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformReleaseEntities(releaseEntities) >> response
@@ -359,7 +360,7 @@ class ReleaseServiceImplTest extends Specification {
     def artists = ["Metallica"]
 
     when:
-    underTest.findAllReleasesSince(artists, date)
+    underTest.findAllReleasesSince(artists, date, sorting)
 
     then:
     1 * underTest.releaseRepository.findAllByReleaseDateAfterAndArtistIn(date, artists, sorting)
@@ -372,7 +373,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.releaseRepository.findAllByReleaseDateAfterAndArtistIn(*_) >> releaseEntities
 
     when:
-    def result = underTest.findAllReleasesSince(["A1"], LocalDate.now())
+    def result = underTest.findAllReleasesSince(["A1"], LocalDate.now(), sorting)
 
     then:
     1 * underTest.releasesResponseTransformer.transformReleaseEntities(releaseEntities) >> response
@@ -413,6 +414,6 @@ class ReleaseServiceImplTest extends Specification {
     underTest.updateReleaseState(id, FAULTY)
 
     then:
-    1 * underTest.releaseRepository.save({args -> args.state == FAULTY})
+    1 * underTest.releaseRepository.save({ args -> args.state == FAULTY })
   }
 }

--- a/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerTest.groovy
@@ -2,6 +2,8 @@ package rocks.metaldetector.butler.web.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.SortHandlerMethodArgumentResolver
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import rocks.metaldetector.butler.model.TimeRange
@@ -18,6 +20,7 @@ import spock.lang.Unroll
 import java.text.SimpleDateFormat
 import java.time.LocalDate
 
+import static org.springframework.data.domain.Sort.Direction.ASC
 import static org.springframework.http.HttpStatus.BAD_REQUEST
 import static org.springframework.http.HttpStatus.OK
 import static org.springframework.http.MediaType.APPLICATION_JSON
@@ -31,9 +34,11 @@ import static rocks.metaldetector.butler.model.release.ReleaseEntityState.FAULTY
 class ReleasesRestControllerTest extends Specification implements WithExceptionResolver {
 
   static final String ARTIST_NAME = "A1"
+  static final Sort DEFAULT_SORTING = Sort.by(ASC, "releaseDate", "artist", "albumTitle")
 
   ReleasesRestController underTest = new ReleasesRestController(releaseService: Mock(ReleaseService))
-  MockMvc mockMvc = MockMvcBuilders.standaloneSetup(underTest, exceptionResolver()).build()
+  MockMvc mockMvc = MockMvcBuilders.standaloneSetup(underTest, exceptionResolver())
+      .setCustomArgumentResolvers(new SortHandlerMethodArgumentResolver()).build()
   ObjectMapper objectMapper = new ObjectMapper(dateFormat: new SimpleDateFormat("yyyy-MM-dd"))
 
   void setup() {
@@ -41,6 +46,24 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
   }
 
   def "getAllReleases: should call releases service if no time range is given"() {
+    given:
+    def artists = [ARTIST_NAME]
+    def releasesRequest = new ReleasesRequest(artists: artists)
+    def expectedSorting = Sort.by(ASC, "artist")
+    def request = post(RELEASES_UNPAGINATED)
+        .param("sort", "artist,asc")
+        .contentType(APPLICATION_JSON)
+        .accept(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(releasesRequest))
+
+    when:
+    mockMvc.perform(request).andReturn()
+
+    then:
+    1 * underTest.releaseService.findAllUpcomingReleases(artists, expectedSorting)
+  }
+
+  def "getAllReleases: should use default sorting if none is given"() {
     given:
     def artists = [ARTIST_NAME]
     def releasesRequest = new ReleasesRequest(artists: artists)
@@ -53,7 +76,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     mockMvc.perform(request).andReturn()
 
     then:
-    1 * underTest.releaseService.findAllUpcomingReleases(artists)
+    1 * underTest.releaseService.findAllUpcomingReleases(artists, DEFAULT_SORTING)
   }
 
   def "getAllReleases: should return ok if no time range is given"() {
@@ -79,7 +102,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
         .contentType(APPLICATION_JSON)
         .accept(APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(releasesRequest))
-    underTest.releaseService.findAllUpcomingReleases(_) >> expectedReleasesReponse
+    underTest.releaseService.findAllUpcomingReleases(*_) >> expectedReleasesReponse
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -89,7 +112,27 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     releasesResponse == expectedReleasesReponse
   }
 
-  def "getAllReleases: should call releases service if time range is given"() {
+  def "getAllReleases with TimeRange: should call releases service if time range is given"() {
+    given:
+    def from = LocalDate.of(2020, 1, 1)
+    def to = LocalDate.of(2020, 2, 1)
+    def artists = [ARTIST_NAME]
+    def requestDto = new ReleasesRequest(artists: artists, dateFrom: from, dateTo: to)
+    def expectedSorting = Sort.by(ASC, "artist")
+    def request = post(RELEASES_UNPAGINATED)
+        .param("sort", "artist,asc")
+        .contentType(APPLICATION_JSON)
+        .accept(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestDto))
+
+    when:
+    mockMvc.perform(request).andReturn()
+
+    then:
+    1 * underTest.releaseService.findAllReleasesForTimeRange(artists, TimeRange.of(from, to), expectedSorting)
+  }
+
+  def "getAllReleases with TimeRange: should use default sorting if none is given"() {
     given:
     def from = LocalDate.of(2020, 1, 1)
     def to = LocalDate.of(2020, 2, 1)
@@ -104,10 +147,10 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     mockMvc.perform(request).andReturn()
 
     then:
-    1 * underTest.releaseService.findAllReleasesForTimeRange(artists, TimeRange.of(from, to))
+    1 * underTest.releaseService.findAllReleasesForTimeRange(artists, TimeRange.of(from, to), DEFAULT_SORTING)
   }
 
-  def "getAllReleases: should return ok if time range is given"() {
+  def "getAllReleases with TimeRange: should return ok if time range is given"() {
     given:
     def requestDto = new ReleasesRequest(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1), dateTo: LocalDate.of(2020, 2, 1))
     def request = post(RELEASES_UNPAGINATED)
@@ -122,7 +165,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     result.response.status == OK.value()
   }
 
-  def "getAllReleases: should return result from release service if time range is given"() {
+  def "getAllReleases with TimeRange: should return result from release service if time range is given"() {
     given:
     def requestDto = new ReleasesRequest(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1), dateTo: LocalDate.of(2020, 2, 1))
     def expectedReleasesResponse = createReleasesResponse()
@@ -140,7 +183,26 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     releasesResponse == expectedReleasesResponse
   }
 
-  def "getAllReleases: should call releases service if only 'dateFrom' is given"() {
+  def "getAllReleases from: should call releases service if only 'dateFrom' is given"() {
+    given:
+    def from = LocalDate.of(2020, 1, 1)
+    def artists = [ARTIST_NAME]
+    def requestDto = new ReleasesRequest(artists: artists, dateFrom: from)
+    def expectedSorting = Sort.by(ASC, "artist")
+    def request = post(RELEASES_UNPAGINATED)
+        .param("sort", "artist,asc")
+        .contentType(APPLICATION_JSON)
+        .accept(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestDto))
+
+    when:
+    mockMvc.perform(request).andReturn()
+
+    then:
+    1 * underTest.releaseService.findAllReleasesSince(artists, from, expectedSorting) >> []
+  }
+
+  def "getAllReleases from: should use default sorting if none is given"() {
     given:
     def from = LocalDate.of(2020, 1, 1)
     def artists = [ARTIST_NAME]
@@ -154,10 +216,10 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     mockMvc.perform(request).andReturn()
 
     then:
-    1 * underTest.releaseService.findAllReleasesSince(artists, from) >> []
+    1 * underTest.releaseService.findAllReleasesSince(artists, from, DEFAULT_SORTING) >> []
   }
 
-  def "getAllReleases: should return ok if only 'dateFrom' is given"() {
+  def "getAllReleases from: should return ok if only 'dateFrom' is given"() {
     given:
     def requestDto = new ReleasesRequest(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1))
     def request = post(RELEASES_UNPAGINATED)
@@ -172,7 +234,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     result.response.status == OK.value()
   }
 
-  def "getAllReleases: should return result from release service if only 'dateFrom' is given"() {
+  def "getAllReleases from: should return result from release service if only 'dateFrom' is given"() {
     given:
     def requestDto = new ReleasesRequest(artists: [ARTIST_NAME], dateFrom: LocalDate.of(2020, 1, 1))
     def expectedReleasesResponse = createReleasesResponse()
@@ -235,6 +297,24 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     given:
     def artists = [ARTIST_NAME]
     def releasesRequest = new ReleasesRequestPaginated(artists: artists, page: 1, size: 10)
+    def expectedSorting = Sort.by(ASC, "artist")
+    def request = post(RELEASES)
+        .param("sort", "artist,asc")
+        .contentType(APPLICATION_JSON)
+        .accept(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(releasesRequest))
+
+    when:
+    mockMvc.perform(request).andReturn()
+
+    then:
+    1 * underTest.releaseService.findAllUpcomingReleases(releasesRequest.artists, releasesRequest.page, releasesRequest.size, expectedSorting)
+  }
+
+  def "getPaginatedReleases: valid request without time range should call releases service with default sorting if none is given"() {
+    given:
+    def artists = [ARTIST_NAME]
+    def releasesRequest = new ReleasesRequestPaginated(artists: artists, page: 1, size: 10)
     def request = post(RELEASES)
         .contentType(APPLICATION_JSON)
         .accept(APPLICATION_JSON)
@@ -244,7 +324,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     mockMvc.perform(request).andReturn()
 
     then:
-    1 * underTest.releaseService.findAllUpcomingReleases(releasesRequest.artists, releasesRequest.page, releasesRequest.size)
+    1 * underTest.releaseService.findAllUpcomingReleases(releasesRequest.artists, releasesRequest.page, releasesRequest.size, DEFAULT_SORTING)
   }
 
   def "getPaginatedReleases: valid request without time range should return ok"() {
@@ -286,6 +366,26 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     def to = LocalDate.of(2020, 2, 1)
     def artists = [ARTIST_NAME]
     def requestDto = new ReleasesRequestPaginated(artists: artists, dateFrom: from, dateTo: to, page: 1, size: 10)
+    def expectedSorting = Sort.by(ASC, "artist")
+    def request = post(RELEASES)
+        .param("sort", "artist,asc")
+        .contentType(APPLICATION_JSON)
+        .accept(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestDto))
+
+    when:
+    mockMvc.perform(request).andReturn()
+
+    then:
+    1 * underTest.releaseService.findAllReleasesForTimeRange(artists, TimeRange.of(from, to), requestDto.page, requestDto.size, expectedSorting)
+  }
+
+  def "getPaginatedReleases: valid request with time range should call releases service with default sorting if none is given"() {
+    given:
+    def from = LocalDate.of(2020, 1, 1)
+    def to = LocalDate.of(2020, 2, 1)
+    def artists = [ARTIST_NAME]
+    def requestDto = new ReleasesRequestPaginated(artists: artists, dateFrom: from, dateTo: to, page: 1, size: 10)
     def request = post(RELEASES)
         .contentType(APPLICATION_JSON)
         .accept(APPLICATION_JSON)
@@ -295,7 +395,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     mockMvc.perform(request).andReturn()
 
     then:
-    1 * underTest.releaseService.findAllReleasesForTimeRange(artists, TimeRange.of(from, to), requestDto.page, requestDto.size)
+    1 * underTest.releaseService.findAllReleasesForTimeRange(artists, TimeRange.of(from, to), requestDto.page, requestDto.size, DEFAULT_SORTING)
   }
 
   def "getPaginatedReleases: valid request with time range should return ok"() {
@@ -336,6 +436,25 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     def from = LocalDate.of(2020, 1, 1)
     def artists = [ARTIST_NAME]
     def requestDto = new ReleasesRequestPaginated(artists: artists, dateFrom: from, page: 1, size: 10)
+    def expectedSorting = Sort.by(ASC, "artist")
+    def request = post(RELEASES)
+        .param("sort", "artist,asc")
+        .contentType(APPLICATION_JSON)
+        .accept(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(requestDto))
+
+    when:
+    mockMvc.perform(request).andReturn()
+
+    then:
+    1 * underTest.releaseService.findAllReleasesSince(artists, from, requestDto.page, requestDto.size, expectedSorting) >> []
+  }
+
+  def "getPaginatedReleases: should call releases service with default sorting if only 'dateFrom' and no sorting is given"() {
+    given:
+    def from = LocalDate.of(2020, 1, 1)
+    def artists = [ARTIST_NAME]
+    def requestDto = new ReleasesRequestPaginated(artists: artists, dateFrom: from, page: 1, size: 10)
     def request = post(RELEASES)
         .contentType(APPLICATION_JSON)
         .accept(APPLICATION_JSON)
@@ -345,7 +464,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     mockMvc.perform(request).andReturn()
 
     then:
-    1 * underTest.releaseService.findAllReleasesSince(artists, from, requestDto.page, requestDto.size) >> []
+    1 * underTest.releaseService.findAllReleasesSince(artists, from, requestDto.page, requestDto.size, DEFAULT_SORTING) >> []
   }
 
   def "getPaginatedReleases: should return ok if only 'dateFrom' is given"() {
@@ -396,7 +515,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     result.response.status == BAD_REQUEST.value()
 
     and:
-    0 * underTest.releaseService.findAllUpcomingReleases(_)
+    0 * underTest.releaseService.findAllUpcomingReleases(*_)
     0 * underTest.releaseService.findAllReleasesForTimeRange(*_)
 
     where:
@@ -462,7 +581,7 @@ class ReleasesRestControllerTest extends Specification implements WithExceptionR
     def request = put("${RELEASES}/0")
         .contentType(APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(new ReleaseUpdateRequest(FAULTY)))
-    underTest.releaseService.updateReleaseState(*_) >> {throw new IllegalArgumentException()}
+    underTest.releaseService.updateReleaseState(*_) >> { throw new IllegalArgumentException() }
 
     when:
     def result = mockMvc.perform(request).andReturn()


### PR DESCRIPTION
All endpoints for releases now can be called with a sorting parameter. The default stays as is.