### PR TITLE
rework s3 upload exception handling

### DIFF
--- a/src/main/groovy/rocks/metaldetector/butler/service/cover/S3PersistenceService.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/cover/S3PersistenceService.groovy
@@ -1,6 +1,5 @@
 package rocks.metaldetector.butler.service.cover
 
-import com.amazonaws.SdkClientException
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.ObjectMetadata
@@ -39,8 +38,8 @@ class S3PersistenceService implements CoverPersistenceService {
       URL s3Url = amazonS3Client.getUrl(bucketName, key)
       return "${awsS3Host}/${bucketName}${s3Url.path}"
     }
-    catch (SdkClientException ex) {
-      log.error("Could not upload cover from '${coverUrl.toExternalForm()}'", ex)
+    catch (FileNotFoundException ex) {
+      log.warn("Could not find cover '${coverUrl.toExternalForm()}'. The upload to S3 is skipped.", ex)
       return null
     }
   }

--- a/src/test/groovy/rocks/metaldetector/butler/service/cover/S3PersistenceServiceTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/cover/S3PersistenceServiceTest.groovy
@@ -80,15 +80,12 @@ class S3PersistenceServiceTest extends Specification {
   }
 
   @Unroll
-  "if upload fails with '#exception.class' null is returned"() {
+  "if upload fails with 'FileNotFoundException' null is returned"() {
     given:
-    underTest.amazonS3Client.putObject(*_) >> { throw exception }
+    underTest.amazonS3Client.putObject(*_) >> { throw new FileNotFoundException() }
 
     expect:
     underTest.persistCover(coverUrl) == null
-
-    where:
-    exception << [new SdkClientException("exception"), new AmazonServiceException("exeption")]
   }
 
   def "getUrl: client is called with bucket name"() {


### PR DESCRIPTION
If a `FileNotFoundException` occurs, the upload of the cover should be skipped. 

All other exceptions are handled by the `ReleaseImporter` and the import is evaluated as `ERROR`.

This might not be the final solution yet. I want to see how we can minimize the noise in Slack.