### PR TITLE
prepare for docker swarm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF
 LABEL org.label-schema.version=$BUILD_DATE
 
 COPY $SOURCE_JAR_FILE app.jar
+COPY docker-entrypoint.sh /app
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,4 @@ volumes:
 
 networks:
   butler-network:
+    name: butler-network

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+
+	export "$var"="$val"
+
+	unset "$fileVar"
+}
+
+envs=(
+  DATASOURCE_USERNAME
+  DATASOURCE_PASSWORD
+  AWS_ACCESS_KEY
+  AWS_SECRET_KEY
+  JWT_SECRET
+)
+
+for e in "${envs[@]}"; do
+  file_env "$e"
+done
+
+exec "$@"

--- a/src/main/groovy/rocks/metaldetector/butler/service/converter/TimeForMetalReleaseEntityConverter.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/converter/TimeForMetalReleaseEntityConverter.groovy
@@ -42,7 +42,8 @@ class TimeForMetalReleaseEntityConverter implements Converter<String, List<Relea
             setAlbumTitle(builder, it.td[2].toString())
             setReleaseDate(builder, it.td[0].toString())
             setReleaseType(builder, it.td[2].toString())
-            setCoverSourceUrl(builder, it.td[1].a[0].img[0] as NodeChild)
+            setReleaseDetailsUrl(builder, it.td[1].a[0].img[0] as NodeChild)
+            builder.type(FULL_LENGTH)
             return builder.build()
           }
     }
@@ -77,7 +78,7 @@ class TimeForMetalReleaseEntityConverter implements Converter<String, List<Relea
     rawValue.endsWith(EP_SUFFIX) ? builder.type(EP) : builder.type(FULL_LENGTH)
   }
 
-  private void setCoverSourceUrl(def builder, NodeChild rawSource) {
+  private void setReleaseDetailsUrl(def builder, NodeChild rawSource) {
     def sourceUrl = rawSource.attributes()["src"] as String
     sourceUrl.replaceAll(ANY_DASH_REGEX, "-")
     builder.releaseDetailsUrl(sourceUrl)

--- a/src/test/groovy/rocks/metaldetector/butler/service/converter/TimeForMetalReleaseEntityConverterTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/converter/TimeForMetalReleaseEntityConverterTest.groovy
@@ -4,7 +4,6 @@ import groovy.xml.XmlSlurper
 import groovy.xml.slurpersupport.NodeChild
 import org.springframework.core.io.ClassPathResource
 import rocks.metaldetector.butler.model.release.ReleaseEntity
-import rocks.metaldetector.butler.model.release.ReleaseType
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -120,7 +119,7 @@ class TimeForMetalReleaseEntityConverterTest extends Specification {
     nodeChildMock.attributes() >> [src: sourceUrl]
 
     when:
-    underTest.setCoverSourceUrl(releaseEntityBuilder, nodeChildMock)
+    underTest.setReleaseDetailsUrl(releaseEntityBuilder, nodeChildMock)
 
     then:
     def releaseEntity = releaseEntityBuilder.build()


### PR DESCRIPTION
Docker Swarm manages the secrets encrypted on the host. If a container shall use a secret, docker mounts it via a file in the container. The container must therefore be smart enough to set an ENV from the contents of a file. This is now done by the new `docker-entrypoint.sh` that is copied into the docker image. 

For example, `docker run` can be executed as follows:

```bash
docker run -e JWT_SECRET=my-secret metaldetector/metal-release-butler
```

We already know that.

Now, also possible is:

```bash
docker run -e JWT_SECRET_FILE=/path/to/secret metaldetector/metal-release-butler
```

The last variant will expose the contents of the file to the ENV `JWT_SECRET`.