### PR TITLE
Time For Metal Converter album title bug with EPs fixed

### DIFF
--- a/src/main/groovy/rocks/metaldetector/butler/service/converter/TimeForMetalReleaseEntityConverter.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/converter/TimeForMetalReleaseEntityConverter.groovy
@@ -65,7 +65,7 @@ class TimeForMetalReleaseEntityConverter implements Converter<String, List<Relea
         albumTitle += " - ${it}"
       }
     }
-    albumTitle = albumTitle.replaceAll(EP_SUFFIX, "")
+    albumTitle = albumTitle.replace(EP_SUFFIX, "")
     builder.albumTitle(albumTitle.trim().strip())
   }
 

--- a/src/test/groovy/rocks/metaldetector/butler/service/converter/TimeForMetalReleaseEntityConverterTest.groovy
+++ b/src/test/groovy/rocks/metaldetector/butler/service/converter/TimeForMetalReleaseEntityConverterTest.groovy
@@ -55,9 +55,9 @@ class TimeForMetalReleaseEntityConverterTest extends Specification {
 
     where:
     rawValue << [
-            "Artist 1 - Album",
-            "     Artist 1     -    Album",
-            "Artist 1 $LONG_DASH Album"
+        "Artist 1 - Album",
+        "     Artist 1     -    Album",
+        "Artist 1 $LONG_DASH Album"
     ]
   }
 
@@ -77,6 +77,7 @@ class TimeForMetalReleaseEntityConverterTest extends Specification {
     title                                       | expectedTitle
     "Artist 1 - Album 1"                        | "Album 1"
     "Artist 1 -      Album 1        "           | "Album 1"
+    "Artist 1 - Album 1 (EP)"                   | "Album 1"
     "Artist 1 - Album 1 - Live - 1964"          | "Album 1 - Live - 1964"
     "Artist 1 $LONG_DASH Album 1 - Live - 1964" | "Album 1 - Live - 1964"
   }
@@ -105,10 +106,10 @@ class TimeForMetalReleaseEntityConverterTest extends Specification {
     releaseEntity.type == expectedReleaseType
 
     where:
-    rawValue                   | expectedReleaseType
-    "Artist - Album"           | FULL_LENGTH
-    "Artist - Album (Single)"  | FULL_LENGTH
-    "Artist - Album (EP)"      | EP
+    rawValue                  | expectedReleaseType
+    "Artist - Album"          | FULL_LENGTH
+    "Artist - Album (Single)" | FULL_LENGTH
+    "Artist - Album (EP)"     | EP
   }
 
   def "cover source url is set"() {


### PR DESCRIPTION
Currently all EP's album titles from TimeForMetal ended with "Title ()". The problem was the use of replaceAll instead of replace. replaceAll takes a regex as first parameter and not a char sequence.