### PR TITLE
improve docker healthcheck

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,4 +51,3 @@ jobs:
           build-args: |
             BUILD_DATE=${{ steps.version.outputs.version }}
             VCS_REF=${{ github.ref }}
-            HEALTH_CHECK_ENDPOINT=${{ secrets.HEALTH_CHECK_ENDPOINT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ VOLUME ["/app/images/", "/app/logs/"]
 ARG SOURCE_JAR_FILE="build/libs/*.jar"
 ARG BUILD_DATE
 ARG VCS_REF
-ARG HEALTH_CHECK_ENDPOINT
 
 # Labels
 LABEL org.label-schema.schema-version="1.0"
@@ -34,7 +33,7 @@ LABEL org.label-schema.vcs-url="https://github.com/MetalDetectorRocks/metal-rele
 LABEL org.label-schema.vcs-ref=$VCS_REF
 LABEL org.label-schema.version=$BUILD_DATE
 
-HEALTHCHECK --start-period=10s --interval=10s --timeout=5s --retries=3 CMD curl --fail http://localhost:8080/$HEALTH_CHECK_ENDPOINT || exit 1
+HEALTHCHECK --start-period=30s --interval=10s --timeout=5s --retries=3 CMD curl --fail http://localhost:8080/actuator/health || exit 1
 
 COPY $SOURCE_JAR_FILE app.jar
 COPY docker-entrypoint.sh /app

--- a/src/main/resources/application-preview.yml
+++ b/src/main/resources/application-preview.yml
@@ -24,4 +24,7 @@ aws:
 management:
   endpoints:
     web:
-      base-path: ${ACTUATOR_BASE_PATH}
+      path-mapping.info: ${ACTUATOR_INFO_PATH}
+      path-mapping.metrics: ${ACTUATOR_METRICS_PATH}
+      path-mapping.prometheus: ${ACTUATOR_PROMETHEUS_PATH}
+      path-mapping.flyway: ${ACTUATOR_FLYWAY_PATH}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,4 +21,7 @@ aws:
 management:
   endpoints:
     web:
-      base-path: ${ACTUATOR_BASE_PATH}
+      path-mapping.info: ${ACTUATOR_INFO_PATH}
+      path-mapping.metrics: ${ACTUATOR_METRICS_PATH}
+      path-mapping.prometheus: ${ACTUATOR_PROMETHEUS_PATH}
+      path-mapping.flyway: ${ACTUATOR_FLYWAY_PATH}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,4 +86,4 @@ management:
     web:
       base-path: /actuator
       exposure:
-        include: health, info, metrics, prometheus
+        include: health, info, metrics, prometheus, flyway


### PR DESCRIPTION
The path for the healthcheck must be specified directly in the Dockerfile. A placeholder mechanism does not work here. 

Therefore, we now work without obfuscation for the `/health` endpoint. The endpoints `/info`, `/metrics`, `/prometheus` and `/flyway` will hide behind an obfuscated URL.