### PR TITLE
Fix npe in MetalArchivesReissueTask

### DIFF
--- a/src/main/groovy/rocks/metaldetector/butler/service/importjob/MetalArchivesReissueTask.groovy
+++ b/src/main/groovy/rocks/metaldetector/butler/service/importjob/MetalArchivesReissueTask.groovy
@@ -15,7 +15,7 @@ class MetalArchivesReissueTask implements Runnable {
       def releaseId = urlParts[urlParts.length - 1]
       def document = webCrawler.requestOtherReleases(releaseId)
       Set<String> distinctDateRows = document?.getElementsByTag("a")?.drop(1)
-                                         ?.collect { it?.childNode(0)?.value as String } - null
+                                         ?.collect { it?.childNode(0)?.value as String }?.findAll()
       releaseEntity.reissue = distinctDateRows.size() > 1
     }
   }


### PR DESCRIPTION
If the document is null (or anything in it), null-items cannot be substracted, so a nullsafe findAll is better here.