### PR TITLE
Fix path to jars in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ EXPOSE $SERVER_PORT
 VOLUME ["/app/images/", "/app/logs/"]
 
 # Arguments
-ARG SOURCE_JAR_FILE="build/libs/*.jar"
+ARG SOURCE_JAR_FILE="app/build/libs/*.jar"
 ARG BUILD_DATE
 ARG VCS_REF
 


### PR DESCRIPTION
The docker build fails currently. Could you please take a look at lines 18 and 41 in the dockerfile? Do we have to adjust these paths too? I'm a bit confused that the "app" segment already exists there 🤔 