### PR TITLE
rework restart policy and use 'butler' namespace for volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   butler-db:
-    container_name: butler-db-main
+    container_name: butler-db
     image: postgres:13.1-alpine
     environment:
       POSTGRES_PASSWORD: secret
@@ -16,10 +16,15 @@ services:
         target: /var/lib/postgresql/data
     ports:
       - "5432:5432"
-    restart: on-failure:3
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
   auth-db:
-    container_name: auth-db
+    container_name: butler-auth-db
     image: postgres:13.1-alpine
     environment:
       POSTGRES_PASSWORD: secret
@@ -33,10 +38,15 @@ services:
         target: /var/lib/postgresql/data
     ports:
       - "5433:5432"
-    restart: on-failure:3
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
   auth-app:
-    container_name: auth-app
+    container_name: butler-auth-app
     image: metaldetector/metal-detector-auth
     environment:
       DATASOURCE_URL: jdbc:postgresql://auth-db:5432/metal-detector-auth
@@ -52,13 +62,18 @@ services:
       - auth-network
     ports:
       - "9000:8080"
-    restart: on-failure:3
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
 
 volumes:
   butler-db-volume:
     name: butler-db
   auth-db-volume:
-    name: auth-db
+    name: butler-auth-db
 
 networks:
   butler-network:


### PR DESCRIPTION
IntelliJ complains about the restart policy. 

I also decided to use some kind of namespace for the volumes here, because volumes with the same naming are also created by the Detector and sharing them is not so easy.