### PR TITLE
Improved HttpStatus on errors and overall code coverage

### DIFF
--- a/app/src/main/groovy/rocks/metaldetector/butler/config/swagger/SwaggerConfig.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/config/swagger/SwaggerConfig.groovy
@@ -2,8 +2,6 @@ package rocks.metaldetector.butler.config.swagger
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import springfox.documentation.builders.PathSelectors
 import springfox.documentation.builders.RequestHandlerSelectors
 import springfox.documentation.spi.DocumentationType
@@ -12,12 +10,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2
 
 @Configuration
 @EnableSwagger2
-class SwaggerConfig implements WebMvcConfigurer {
-
-  @Override
-  void addResourceHandlers(final ResourceHandlerRegistry registry) {
-    registry.addResourceHandler("/resources/**").addResourceLocations("/resources/config/swagger/")
-  }
+class SwaggerConfig {
 
   @Bean
   Docket api() {

--- a/app/src/main/groovy/rocks/metaldetector/butler/config/web/ResourceNotFoundException.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/config/web/ResourceNotFoundException.groovy
@@ -1,0 +1,10 @@
+package rocks.metaldetector.butler.config.web;
+
+class ResourceNotFoundException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  ResourceNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/app/src/main/groovy/rocks/metaldetector/butler/config/web/WebMvcConfig.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/config/web/WebMvcConfig.groovy
@@ -1,0 +1,16 @@
+package rocks.metaldetector.butler.config.web
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig implements WebMvcConfigurer {
+
+  @Override
+  void addResourceHandlers(final ResourceHandlerRegistry registry) {
+    registry
+        .addResourceHandler("/resources/**")
+        .addResourceLocations("/resources/config/swagger/")
+  }
+}

--- a/app/src/main/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinder.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinder.groovy
@@ -3,6 +3,7 @@ package rocks.metaldetector.butler.service.release
 import org.springframework.core.io.FileUrlResource
 import org.springframework.core.io.Resource
 import org.springframework.stereotype.Service
+import rocks.metaldetector.butler.config.web.ResourceNotFoundException
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -11,28 +12,26 @@ import java.nio.file.Paths
 @Service
 class ImageResourceFinder {
 
+  static final String ERROR_MESSAGE_DOTS = "It's not allowed to move between folders. Please specify the complete path relative to the project directory."
+  static final String ERROR_MESSAGE_EXTENSION = "it's only allowed to load images with the following file extensions: "
+  static final String ERROR_MESSAGE_NOT_FOUND = "Image not found"
   static final String[] VALID_FILE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".JPG", ".JPEG", ".PNG", ".GIF"]
 
-  Optional<Resource> findImage(Path location) {
+  Resource findImage(Path location) {
     Path path = Paths.get(System.getProperty("user.dir")).resolve(location)
-    if (isValid(path)) {
-      return Optional.of(new FileUrlResource(path.toUri().toURL()))
-    }
-
-    return Optional.empty()
+    validatePath(path)
+    return new FileUrlResource(path.toUri().toURL())
   }
 
-  private boolean isValid(Path path) {
-    if (path.contains("..")) {
-      throw new IllegalArgumentException("It's not allowed to move between folders. Please specify the complete path relative to the project directory.")
+  private void validatePath(Path path) {
+    if (path.toString().contains("..")) {
+      throw new ResourceNotFoundException(ERROR_MESSAGE_DOTS)
     }
-    else if (!path.toString().endsWithAny(VALID_FILE_EXTENSIONS)) {
-      throw new IllegalArgumentException("it's only allowed to load images with the following file extensions: $VALID_FILE_EXTENSIONS")
+    if (!path.toString().endsWithAny(VALID_FILE_EXTENSIONS)) {
+      throw new ResourceNotFoundException("$ERROR_MESSAGE_EXTENSION$VALID_FILE_EXTENSIONS")
     }
-    else if (Files.notExists(path)) {
-      return false
+    if (Files.notExists(path)) {
+      throw new ResourceNotFoundException(ERROR_MESSAGE_NOT_FOUND)
     }
-
-    return true
   }
 }

--- a/app/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImpl.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImpl.groovy
@@ -6,6 +6,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import rocks.metaldetector.butler.config.web.ResourceNotFoundException
 import rocks.metaldetector.butler.persistence.domain.TimeRange
 import rocks.metaldetector.butler.persistence.domain.release.ReleaseEntityState
 import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
@@ -97,11 +98,8 @@ class ReleaseServiceImpl implements ReleaseService {
   @Override
   @Transactional
   void updateReleaseState(long releaseId, ReleaseEntityState state) {
-    def releaseEntityOptional = releaseRepository.findById(releaseId)
-    if (releaseEntityOptional.empty) {
-      throw new IllegalArgumentException("${releaseId} not present!")
-    }
-    def releaseEntity = releaseEntityOptional.get()
+    def releaseEntity = releaseRepository.findById(releaseId)
+        .orElseThrow(() -> new ResourceNotFoundException("${releaseId} not present!"))
     releaseEntity.state = state
     releaseRepository.save(releaseEntity)
   }

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesRequest.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesRequest.groovy
@@ -22,7 +22,7 @@ class ReleasesRequest {
   }
 
   @AssertTrue(message = "If both dates are set, dateFrom has to be equal to or before dateTo!")
-  boolean isValidIfSetFromBeforeTo() {
+  boolean isDateFromBeforeDateTo() {
     if (dateFrom != null && dateTo != null) {
       return dateFrom == dateTo || dateFrom.isBefore(dateTo)
     }
@@ -30,7 +30,7 @@ class ReleasesRequest {
   }
 
   @AssertTrue(message = "dateTo cannot be set without dateFrom!")
-  boolean isValidNotOnlyDateToSet() {
+  boolean isValidRange() {
     return dateTo == null || dateFrom != null
   }
 }

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesRequest.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesRequest.groovy
@@ -3,6 +3,7 @@ package rocks.metaldetector.butler.web.api
 import groovy.transform.Canonical
 import org.springframework.format.annotation.DateTimeFormat
 
+import javax.validation.constraints.AssertTrue
 import java.time.LocalDate
 
 @Canonical
@@ -20,4 +21,16 @@ class ReleasesRequest {
     return artists ?: Collections.emptyList() as Iterable<String>
   }
 
+  @AssertTrue(message = "If both dates are set, dateFrom has to be equal to or before dateTo!")
+  boolean isValidIfSetFromBeforeTo() {
+    if (dateFrom != null && dateTo != null) {
+      return dateFrom == dateTo || dateFrom.isBefore(dateTo)
+    }
+    return true
+  }
+
+  @AssertTrue(message = "dateTo cannot be set without dateFrom!")
+  boolean isValidNotOnlyDateToSet() {
+    return dateTo == null || dateFrom != null
+  }
 }

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesRequestPaginated.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/api/ReleasesRequestPaginated.groovy
@@ -1,15 +1,12 @@
 package rocks.metaldetector.butler.web.api
 
 import groovy.transform.Canonical
-import org.springframework.format.annotation.DateTimeFormat
 
-import javax.validation.constraints.AssertTrue
 import javax.validation.constraints.Max
 import javax.validation.constraints.Min
-import java.time.LocalDate
 
 @Canonical
-class ReleasesRequestPaginated {
+class ReleasesRequestPaginated extends ReleasesRequest {
 
   @Min(value = 1L, message = "'page' must be greater than zero!")
   int page
@@ -18,25 +15,6 @@ class ReleasesRequestPaginated {
   @Max(value = 50L, message = "'size' must be equal or less than 50!")
   int size
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-  LocalDate dateFrom
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-  LocalDate dateTo
-
   String query
 
-  Iterable<String> artists
-
-  Iterable<String> getArtists() {
-    return artists ?: Collections.emptyList() as Iterable<String>
-  }
-
-  @AssertTrue(message = "If dates are set, dateFrom has to be equal to or before dateTo!")
-  private boolean isValid() {
-    if (dateFrom != null && dateTo != null) {
-      return dateFrom == dateTo || dateFrom.isBefore(dateTo)
-    }
-    return true
-  }
 }

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleaseCoverRestController.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleaseCoverRestController.groovy
@@ -27,7 +27,7 @@ class ReleaseCoverRestController {
 
   @GetMapping(produces = [IMAGE_JPEG_VALUE, IMAGE_GIF_VALUE, IMAGE_PNG_VALUE])
   ResponseEntity<Resource> getReleaseCover(@RequestParam String id) {
-    Optional<Resource> coverResource = imageResourceFinder.findImage(Paths.get("images", id))
-    return ResponseEntity.of(coverResource)
+    Resource coverResource = imageResourceFinder.findImage(Paths.get("images", id))
+    return ResponseEntity.ok(coverResource)
   }
 }

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestController.groovy
@@ -35,7 +35,7 @@ class ReleasesRestController {
   @PreAuthorize("hasAuthority('SCOPE_releases-read')")
   ResponseEntity<ReleasesResponse> getPaginatedReleases(@Valid @RequestBody ReleasesRequestPaginated request,
                                                         @SortDefault(sort = ["releaseDate", "artist", "albumTitle"], direction = ASC) Sort sorting) {
-    def releasesResponse
+    def releasesResponse = null
     def query = request.query != null ? request.query.trim() : ""
     def artists = request.artists ? request.artists.collect { it?.toLowerCase() } - null : []
 
@@ -48,9 +48,6 @@ class ReleasesRestController {
     }
     else if (request.dateFrom != null) {
       releasesResponse = releaseService.findAllReleasesSince(artists, request.dateFrom, query, request.page, request.size, sorting)
-    }
-    else {
-      throw new IllegalArgumentException("Please specify a valid date for 'dateFrom' and 'dateTo' or only for 'dateFrom' with format 'YYYY-MM-DD'.")
     }
 
     return ResponseEntity.ok(releasesResponse)
@@ -67,7 +64,7 @@ class ReleasesRestController {
   @PreAuthorize("hasAuthority('SCOPE_releases-read-all')")
   ResponseEntity<ReleasesResponse> getAllReleases(@Valid @RequestBody ReleasesRequest request,
                                                   @SortDefault(sort = ["releaseDate", "artist", "albumTitle"], direction = ASC) Sort sorting) {
-    def releasesResponse
+    def releasesResponse = null
     def artists = request.artists ? request.artists.collect { it?.toLowerCase() } - null : []
 
     if (request.dateFrom == null && request.dateTo == null) {
@@ -78,9 +75,6 @@ class ReleasesRestController {
     }
     else if (request.dateFrom != null) {
       releasesResponse = releaseService.findAllReleasesSince(artists, request.dateFrom, sorting)
-    }
-    else {
-      throw new IllegalArgumentException("Please specify a valid date for 'dateFrom' and 'dateTo' or only for 'dateFrom' with format 'YYYY-MM-DD'.")
     }
 
     return ResponseEntity.ok(releasesResponse)

--- a/app/src/test/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinderTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinderTest.groovy
@@ -25,7 +25,7 @@ class ImageResourceFinderTest extends Specification {
     result
   }
 
-  def "should return throw ResourceNotFoundException if no image resource was found"() {
+  def "should throw ResourceNotFoundException if no image resource was found"() {
     given:
     def location = Paths.get("not-existing-image.jpg")
 

--- a/app/src/test/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinderTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinderTest.groovy
@@ -6,7 +6,9 @@ import spock.lang.Specification
 import java.nio.file.Paths
 
 import static rocks.metaldetector.butler.service.release.ImageResourceFinder.ERROR_MESSAGE_DOTS
+import static rocks.metaldetector.butler.service.release.ImageResourceFinder.ERROR_MESSAGE_EXTENSION
 import static rocks.metaldetector.butler.service.release.ImageResourceFinder.ERROR_MESSAGE_NOT_FOUND
+import static rocks.metaldetector.butler.service.release.ImageResourceFinder.VALID_FILE_EXTENSIONS
 
 class ImageResourceFinderTest extends Specification {
 

--- a/app/src/test/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinderTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinderTest.groovy
@@ -6,9 +6,7 @@ import spock.lang.Specification
 import java.nio.file.Paths
 
 import static rocks.metaldetector.butler.service.release.ImageResourceFinder.ERROR_MESSAGE_DOTS
-import static rocks.metaldetector.butler.service.release.ImageResourceFinder.ERROR_MESSAGE_EXTENSION
 import static rocks.metaldetector.butler.service.release.ImageResourceFinder.ERROR_MESSAGE_NOT_FOUND
-import static rocks.metaldetector.butler.service.release.ImageResourceFinder.VALID_FILE_EXTENSIONS
 
 class ImageResourceFinderTest extends Specification {
 
@@ -46,7 +44,7 @@ class ImageResourceFinderTest extends Specification {
 
     then:
     def thrown = thrown(ResourceNotFoundException)
-    thrown.message == "$ERROR_MESSAGE_EXTENSION$VALID_FILE_EXTENSIONS"
+    thrown.message == ERROR_MESSAGE_EXTENSION$VALID_FILE_EXTENSIONS
   }
 
   def "should throw exception if image location contains two dots"() {

--- a/app/src/test/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinderTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinderTest.groovy
@@ -44,7 +44,7 @@ class ImageResourceFinderTest extends Specification {
 
     then:
     def thrown = thrown(ResourceNotFoundException)
-    thrown.message == ERROR_MESSAGE_EXTENSION$VALID_FILE_EXTENSIONS
+    thrown.message == "$ERROR_MESSAGE_EXTENSION$VALID_FILE_EXTENSIONS"
   }
 
   def "should throw exception if image location contains two dots"() {

--- a/app/src/test/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinderTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/service/release/ImageResourceFinderTest.groovy
@@ -1,8 +1,14 @@
 package rocks.metaldetector.butler.service.release
 
+import rocks.metaldetector.butler.config.web.ResourceNotFoundException
 import spock.lang.Specification
 
 import java.nio.file.Paths
+
+import static rocks.metaldetector.butler.service.release.ImageResourceFinder.ERROR_MESSAGE_DOTS
+import static rocks.metaldetector.butler.service.release.ImageResourceFinder.ERROR_MESSAGE_EXTENSION
+import static rocks.metaldetector.butler.service.release.ImageResourceFinder.ERROR_MESSAGE_NOT_FOUND
+import static rocks.metaldetector.butler.service.release.ImageResourceFinder.VALID_FILE_EXTENSIONS
 
 class ImageResourceFinderTest extends Specification {
 
@@ -16,18 +22,19 @@ class ImageResourceFinderTest extends Specification {
     def result = underTest.findImage(location)
 
     then:
-    result.isPresent()
+    result
   }
 
-  def "should return empty optional if no image resource was found"() {
+  def "should return throw ResourceNotFoundException if no image resource was found"() {
     given:
     def location = Paths.get("not-existing-image.jpg")
 
     when:
-    def result = underTest.findImage(location)
+    underTest.findImage(location)
 
     then:
-    result.isEmpty()
+    def thrown = thrown(ResourceNotFoundException)
+    thrown.message == ERROR_MESSAGE_NOT_FOUND
   }
 
   def "should throw exception if no image location is given"() {
@@ -38,7 +45,8 @@ class ImageResourceFinderTest extends Specification {
     underTest.findImage(location)
 
     then:
-    thrown(IllegalArgumentException)
+    def thrown = thrown(ResourceNotFoundException)
+    thrown.message == "$ERROR_MESSAGE_EXTENSION$VALID_FILE_EXTENSIONS"
   }
 
   def "should throw exception if image location contains two dots"() {
@@ -49,6 +57,7 @@ class ImageResourceFinderTest extends Specification {
     underTest.findImage(location)
 
     then:
-    thrown(IllegalArgumentException)
+    def thrown = thrown(ResourceNotFoundException)
+    thrown.message == ERROR_MESSAGE_DOTS
   }
 }

--- a/app/src/test/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImplTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/service/release/ReleaseServiceImplTest.groovy
@@ -3,6 +3,7 @@ package rocks.metaldetector.butler.service.release
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import rocks.metaldetector.butler.config.web.ResourceNotFoundException
 import rocks.metaldetector.butler.persistence.domain.TimeRange
 import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
 import rocks.metaldetector.butler.web.api.ReleasesResponse
@@ -404,7 +405,7 @@ class ReleaseServiceImplTest extends Specification {
     underTest.updateReleaseState(0L, FAULTY)
 
     then:
-    thrown(IllegalArgumentException)
+    thrown(ResourceNotFoundException)
   }
 
   def "updateReleaseState: should call release repository to update release if present"() {

--- a/app/src/test/groovy/rocks/metaldetector/butler/testutil/WithIntegrationTestConfig.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/testutil/WithIntegrationTestConfig.groovy
@@ -1,7 +1,15 @@
 package rocks.metaldetector.butler.testutil
 
+import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.test.context.TestPropertySource
 
 @TestPropertySource(locations = "classpath:integrationtest.properties")
 interface WithIntegrationTestConfig {
+
+  default Jwt createTokenWithScope(String scope) {
+    return Jwt.withTokenValue("token")
+        .header("alg", "none")
+        .claim("scope", scope)
+        .build()
+  }
 }

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/api/ReleasesRequestTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/api/ReleasesRequestTest.groovy
@@ -14,7 +14,7 @@ class ReleasesRequestTest extends Specification {
                                       dateTo: dateTo)
 
     when:
-    var result = request.isValidIfSetFromBeforeTo()
+    var result = request.isDateFromBeforeDateTo()
 
     then:
     result == expectedResult
@@ -34,7 +34,7 @@ class ReleasesRequestTest extends Specification {
                                       dateTo: dateTo)
 
     when:
-    var result = request.isValidNotOnlyDateToSet()
+    var result = request.isValidRange()
 
     then:
     result == expectedResult

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/api/ReleasesRequestTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/api/ReleasesRequestTest.groovy
@@ -1,0 +1,49 @@
+package rocks.metaldetector.butler.web.api
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.LocalDate
+
+class ReleasesRequestTest extends Specification {
+
+  @Unroll
+  "If both dates are set, dateFrom has to be equal to or before dateTo"() {
+    given:
+    def request = new ReleasesRequest(dateFrom: dateFrom,
+                                      dateTo: dateTo)
+
+    when:
+    var result = request.isValidIfSetFromBeforeTo()
+
+    then:
+    result == expectedResult
+
+    where:
+    dateFrom                 | dateTo                   | expectedResult
+    LocalDate.of(2020, 1, 1) | LocalDate.of(2020, 1, 1) | true
+    LocalDate.of(2020, 1, 1) | LocalDate.of(2021, 1, 1) | true
+    LocalDate.of(2021, 1, 1) | LocalDate.of(2020, 1, 1) | false
+    null                     | null                     | true
+  }
+
+  @Unroll
+  "dateTo cannot be set without dateFrom"() {
+    given:
+    def request = new ReleasesRequest(dateFrom: dateFrom,
+                                      dateTo: dateTo)
+
+    when:
+    var result = request.isValidNotOnlyDateToSet()
+
+    then:
+    result == expectedResult
+
+    where:
+    dateFrom                 | dateTo                   | expectedResult
+    null                     | LocalDate.of(2020, 1, 1) | false
+    LocalDate.of(2020, 1, 1) | LocalDate.of(2021, 1, 1) | true
+    LocalDate.of(2020, 1, 1) | null                     | true
+    null                     | null                     | true
+  }
+}

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestControllerIT.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestControllerIT.groovy
@@ -11,7 +11,6 @@ import rocks.metaldetector.butler.service.importjob.ImportJobService
 import rocks.metaldetector.butler.testutil.WithIntegrationTestConfig
 import spock.lang.Specification
 
-import static org.mockito.Mockito.reset
 import static org.springframework.http.HttpStatus.FORBIDDEN
 import static org.springframework.http.HttpStatus.OK
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -23,15 +22,8 @@ import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.IMPOR
 @AutoConfigureMockMvc
 class ImportJobRestControllerIT extends Specification implements WithIntegrationTestConfig {
 
-  private static Jwt USER_JWT = Jwt.withTokenValue("token")
-      .header("alg", "none")
-      .claim("scope", "releases-read")
-      .build()
-
-  private static Jwt ADMIN_JWT = Jwt.withTokenValue("token")
-      .header("alg", "none")
-      .claim("scope", "import")
-      .build()
+  private final Jwt OTHER_SCOPE_JWT = createTokenWithScope("other-scope")
+  private final Jwt IMPORT_JWT = createTokenWithScope("import")
 
   @SpringBean
   ImportJobService importJobService = Mock(ImportJobService)
@@ -42,14 +34,10 @@ class ImportJobRestControllerIT extends Specification implements WithIntegration
   @Autowired
   MockMvc mockMvc
 
-  void tearDown() {
-    reset(importJobService)
-  }
-
-  def "Admin can GET on import endpoint"() {
+  def "Scope 'import' can GET on import endpoint"() {
     given:
-    jwtDecoder.decode(*_) >> ADMIN_JWT
-    def request = get(IMPORT_JOB).header("Authorization", "Bearer $ADMIN_JWT.tokenValue")
+    jwtDecoder.decode(*_) >> IMPORT_JWT
+    def request = get(IMPORT_JOB).header("Authorization", "Bearer $IMPORT_JWT.tokenValue")
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -58,10 +46,10 @@ class ImportJobRestControllerIT extends Specification implements WithIntegration
     result.response.status == OK.value()
   }
 
-  def "User cannot GET on import endpoint"() {
+  def "Other scopes cannot GET on import endpoint"() {
     given:
-    jwtDecoder.decode(*_) >> USER_JWT
-    def request = get(IMPORT_JOB).header("Authorization", "Bearer $USER_JWT.tokenValue")
+    jwtDecoder.decode(*_) >> OTHER_SCOPE_JWT
+    def request = get(IMPORT_JOB).header("Authorization", "Bearer $OTHER_SCOPE_JWT.tokenValue")
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -70,10 +58,10 @@ class ImportJobRestControllerIT extends Specification implements WithIntegration
     result.response.status == FORBIDDEN.value()
   }
 
-  def "Admin can POST on import endpoint"() {
+  def "Scope 'import' can POST on import endpoint"() {
     given:
-    jwtDecoder.decode(*_) >> ADMIN_JWT
-    def request = post(IMPORT_JOB).header("Authorization", "Bearer $ADMIN_JWT.tokenValue")
+    jwtDecoder.decode(*_) >> IMPORT_JWT
+    def request = post(IMPORT_JOB).header("Authorization", "Bearer $IMPORT_JWT.tokenValue")
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -82,10 +70,10 @@ class ImportJobRestControllerIT extends Specification implements WithIntegration
     result.response.status == OK.value()
   }
 
-  def "User cannot POST on import endpoint"() {
+  def "Other scopes cannot POST on import endpoint"() {
     given:
-    jwtDecoder.decode(*_) >> USER_JWT
-    def request = post(IMPORT_JOB).header("Authorization", "Bearer $USER_JWT.tokenValue")
+    jwtDecoder.decode(*_) >> OTHER_SCOPE_JWT
+    def request = post(IMPORT_JOB).header("Authorization", "Bearer $OTHER_SCOPE_JWT.tokenValue")
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -94,10 +82,10 @@ class ImportJobRestControllerIT extends Specification implements WithIntegration
     result.response.status == FORBIDDEN.value()
   }
 
-  def "Admin can POST on cover reload endpoint"() {
+  def "Scope 'import' can POST on cover reload endpoint"() {
     given:
-    jwtDecoder.decode(*_) >> ADMIN_JWT
-    def request = post(COVER_JOB).header("Authorization", "Bearer " + ADMIN_JWT.tokenValue)
+    jwtDecoder.decode(*_) >> IMPORT_JWT
+    def request = post(COVER_JOB).header("Authorization", "Bearer " + IMPORT_JWT.tokenValue)
 
     when:
     def result = mockMvc.perform(request).andReturn()
@@ -106,10 +94,10 @@ class ImportJobRestControllerIT extends Specification implements WithIntegration
     result.response.status == OK.value()
   }
 
-  def "User cannot POST on cover reload endpoint"() {
+  def "Other scopes cannot POST on cover reload endpoint"() {
     given:
-    jwtDecoder.decode(*_) >> USER_JWT
-    def request = post(COVER_JOB).header("Authorization", "Bearer " + USER_JWT.tokenValue)
+    jwtDecoder.decode(*_) >> OTHER_SCOPE_JWT
+    def request = post(COVER_JOB).header("Authorization", "Bearer " + OTHER_SCOPE_JWT.tokenValue)
 
     when:
     def result = mockMvc.perform(request).andReturn()

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestControllerTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestControllerTest.groovy
@@ -1,33 +1,19 @@
 package rocks.metaldetector.butler.web.rest
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.springframework.http.MediaType
-import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import rocks.metaldetector.butler.service.importjob.ImportJobService
-import rocks.metaldetector.butler.testutil.WithExceptionResolver
 import rocks.metaldetector.butler.web.api.ImportJobResponse
 import rocks.metaldetector.butler.web.dto.ImportJobDto
 import spock.lang.Specification
 
 import static org.springframework.http.HttpStatus.OK
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.COVER_JOB
-import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.IMPORT_JOB
 
-class ImportJobRestControllerTest extends Specification implements WithExceptionResolver {
+class ImportJobRestControllerTest extends Specification {
 
   ImportJobRestController underTest = new ImportJobRestController(importJobService: Mock(ImportJobService))
-  MockMvc mockMvc = MockMvcBuilders.standaloneSetup(underTest, exceptionResolver()).build()
-  ObjectMapper objectMapper = new ObjectMapper()
 
   def "Getting all import job results should call ImportJobService"() {
-    given:
-    def request = get(IMPORT_JOB).accept(MediaType.APPLICATION_JSON)
-
     when:
-    mockMvc.perform(request).andReturn()
+    underTest.getAllImportJobResults()
 
     then:
     1 * underTest.importJobService.findAllImportJobResults()
@@ -35,63 +21,50 @@ class ImportJobRestControllerTest extends Specification implements WithException
 
   def "Getting all import job results should return wrapped result from ImportJobServicee"() {
     given:
-    def request = get(IMPORT_JOB).accept(MediaType.APPLICATION_JSON)
     def importJobDto = new ImportJobDto(jobId: UUID.randomUUID())
     underTest.importJobService.findAllImportJobResults() >> [importJobDto]
 
     when:
-    def result = mockMvc.perform(request).andReturn()
+    def result = underTest.getAllImportJobResults()
 
     then:
-    ImportJobResponse importJobResponse = objectMapper.readValue(result.response.contentAsString, ImportJobResponse)
+    ImportJobResponse importJobResponse = result.body
     importJobResponse.importJobs.size() == 1
     importJobResponse.importJobs[0] == importJobDto
 
     and:
-    result.response.status == OK.value()
+    result.statusCode == OK
   }
 
   def "Creating import job should call ImportJobService"() {
-    given:
-    def request = post(IMPORT_JOB).accept(MediaType.APPLICATION_JSON)
-
     when:
-    mockMvc.perform(request).andReturn()
+    underTest.createImportJob()
 
     then:
     1 * underTest.importJobService.importFromExternalSources()
   }
 
   def "Creating import job should return OK"() {
-    given:
-    def request = post(IMPORT_JOB).accept(MediaType.APPLICATION_JSON)
-
     when:
-    def result = mockMvc.perform(request).andReturn()
+    def result = underTest.createImportJob()
 
     then:
-    result.response.status == OK.value()
+    result.statusCode == OK
   }
 
   def "Retrying cover download should call ImportJobService"() {
-    given:
-    def request = post(COVER_JOB).accept(MediaType.APPLICATION_JSON)
-
     when:
-    mockMvc.perform(request).andReturn()
+    underTest.retryCoverDownload()
 
     then:
     1 * underTest.importJobService.retryCoverDownload()
   }
 
   def "Retrying cover download should return OK"() {
-    given:
-    def request = post(COVER_JOB).accept(MediaType.APPLICATION_JSON)
-
-    when:
-    def result = mockMvc.perform(request).andReturn()
+   when:
+    def result = underTest.retryCoverDownload()
 
     then:
-    result.response.status == OK.value()
+    result.statusCode == OK
   }
 }

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleaseCoverRestControllerIT.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleaseCoverRestControllerIT.groovy
@@ -8,9 +8,14 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.web.servlet.MockMvc
+import rocks.metaldetector.butler.config.web.ResourceNotFoundException
 import rocks.metaldetector.butler.service.release.ImageResourceFinder
 import rocks.metaldetector.butler.testutil.WithIntegrationTestConfig
 import spock.lang.Specification
+
+import static org.springframework.http.HttpStatus.NOT_FOUND
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASE_IMAGES
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -30,18 +35,17 @@ class ReleaseCoverRestControllerIT extends Specification implements WithIntegrat
   @SpringBean
   ImageResourceFinder imageResourceFinder = Mock(ImageResourceFinder)
 
-//  def "should return NOT FOUND for wrong path"() {
-//    given:
-//    jwtDecoder.decode(*_) >> RELEASES_READ_JWT
-//    def request = get("${RELEASE_IMAGES}/?id=test-id")
-//        .accept(IMAGE_JPEG_VALUE, IMAGE_GIF_VALUE, IMAGE_PNG_VALUE)
-//        .header("Authorization", "Bearer $RELEASES_READ_JWT.tokenValue")
-//    imageResourceFinder.findImage(*_) >> { throw new ResourceNotFoundException("not found") }
-//
-//    when:
-//    def result = mockMvc.perform(request).andReturn()
-//
-//    then:
-//    result.response.status == NOT_FOUND.value()
-//  }
+  def "should return NOT FOUND for wrong path"() {
+    given:
+    jwtDecoder.decode(*_) >> RELEASES_READ_JWT
+    def request = get("${RELEASE_IMAGES}/?id=test-id")
+        .header("Authorization", "Bearer $RELEASES_READ_JWT.tokenValue")
+    imageResourceFinder.findImage(*_) >> { throw new ResourceNotFoundException("not found") }
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == NOT_FOUND.value()
+  }
 }

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleaseCoverRestControllerTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleaseCoverRestControllerTest.groovy
@@ -1,71 +1,49 @@
 package rocks.metaldetector.butler.web.rest
 
 import org.springframework.core.io.ClassPathResource
-import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import rocks.metaldetector.butler.service.release.ImageResourceFinder
-import rocks.metaldetector.butler.testutil.WithExceptionResolver
 import spock.lang.Specification
 
 import java.nio.file.Paths
 
-import static org.springframework.http.HttpStatus.NOT_FOUND
 import static org.springframework.http.HttpStatus.OK
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASE_IMAGES
 
-class ReleaseCoverRestControllerTest extends Specification implements WithExceptionResolver {
+class ReleaseCoverRestControllerTest extends Specification {
 
   ReleaseCoverRestController underTest = new ReleaseCoverRestController(imageResourceFinder: Mock(ImageResourceFinder))
-  MockMvc mockMvc = MockMvcBuilders.standaloneSetup(underTest, exceptionResolver()).build()
 
   def "should call image resource finder with image id"() {
     given:
     def coverId = "cover-id"
-    def request = get("${RELEASE_IMAGES}?id={id}", coverId)
 
     when:
-    mockMvc.perform(request).andReturn()
+    underTest.getReleaseCover(coverId)
 
     then:
     1 * underTest.imageResourceFinder.findImage(Paths.get("images", coverId))
   }
 
-  def "should return 404 if no image was found"() {
-    given:
-    def request = get("${RELEASE_IMAGES}?id={id}", "cover-id")
-    underTest.imageResourceFinder.findImage(_) >> Optional.empty()
-
-    when:
-    def result = mockMvc.perform(request).andReturn()
-
-    then:
-    result.response.status == NOT_FOUND.value()
-  }
-
   def "should return OK if image was found"() {
     given:
-    def request = get("${RELEASE_IMAGES}?id={id}", "cover-id")
-    underTest.imageResourceFinder.findImage(_) >> Optional.of(new ClassPathResource("test.jpg"))
+    underTest.imageResourceFinder.findImage(*_) >> new ClassPathResource("test.jpg")
 
     when:
-    def result = mockMvc.perform(request).andReturn()
+    def result = underTest.getReleaseCover("cover-id")
 
     then:
-    result.response.status == OK.value()
+    result.statusCode == OK
   }
 
   def "should return image resource from image resource finder"() {
     given:
     def imageResource = new ClassPathResource("test.jpg")
-    def request = get("${RELEASE_IMAGES}?id={id}", "cover-id")
-    underTest.imageResourceFinder.findImage(_) >> Optional.of(imageResource)
+    underTest.imageResourceFinder.findImage(*_) >> imageResource
 
     when:
-    def result = mockMvc.perform(request).andReturn()
+    def result = underTest.getReleaseCover("cover-id")
 
     then:
-    byte[] resourceAsBytes = result.response.getContentAsByteArray()
+    byte[] resourceAsBytes = result.body.inputStream.bytes
     resourceAsBytes == imageResource.inputStream.bytes
   }
 }

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerIT.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerIT.groovy
@@ -8,16 +8,20 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.web.servlet.MockMvc
+import rocks.metaldetector.butler.config.web.ResourceNotFoundException
 import rocks.metaldetector.butler.service.release.ReleaseService
 import rocks.metaldetector.butler.testutil.WithIntegrationTestConfig
 import rocks.metaldetector.butler.web.api.ReleaseUpdateRequest
 import rocks.metaldetector.butler.web.api.ReleasesRequest
 import rocks.metaldetector.butler.web.api.ReleasesRequestPaginated
 import spock.lang.Specification
+import spock.lang.Unroll
 
-import static org.mockito.Mockito.reset
-import static org.springframework.http.HttpStatus.FORBIDDEN
-import static org.springframework.http.HttpStatus.OK
+import java.time.LocalDate
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST
+import static org.springframework.http.HttpStatus.NOT_FOUND
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 import static org.springframework.http.MediaType.APPLICATION_JSON
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
@@ -30,131 +34,159 @@ import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.UPDAT
 @AutoConfigureMockMvc
 class ReleasesRestControllerIT extends Specification implements WithIntegrationTestConfig {
 
-  private static Jwt USER_JWT = Jwt.withTokenValue("token")
-      .header("alg", "none")
-      .claim("scope", "releases-read")
-      .build()
-
-  @SpringBean
-  ReleaseService releaseService = Mock(ReleaseService)
-
-  @SpringBean
-  JwtDecoder jwtDecoder = Mock(JwtDecoder)
+  private final Jwt RELEASES_READ_JWT = createTokenWithScope("releases-read")
+  private final Jwt RELEASES_READ_ALL_JWT = createTokenWithScope("releases-read-all")
+  private final Jwt RELEASES_WRITE_JWT = createTokenWithScope("releases-write")
+  private static final List<String> ARTISTS = ["a1"]
 
   @Autowired
   MockMvc mockMvc
 
-  ObjectMapper objectMapper = new ObjectMapper()
+  @Autowired
+  ObjectMapper objectMapper
 
-  void tearDown() {
-    reset(releaseService)
-  }
+  @SpringBean
+  JwtDecoder jwtDecoder = Mock(JwtDecoder)
 
-  def "User can access releases endpoint"() {
+  @SpringBean
+  ReleaseService releaseService = Mock(ReleaseService)
+
+  @Unroll
+  "getAllReleases: faulty request should return status UNPROCESSABLE ENTITY"() {
     given:
-    jwtDecoder.decode(*_) >> USER_JWT
-    def requestBody = new ReleasesRequestPaginated(page: 1, size: 10, artists: [])
-    def request = post(RELEASES)
-        .content(objectMapper.writeValueAsString(requestBody))
-        .contentType(APPLICATION_JSON)
-        .header("Authorization", "Bearer $USER_JWT.tokenValue")
-
-    when:
-    def result = mockMvc.perform(request).andReturn()
-
-    then:
-    result.response.status == OK.value()
-  }
-
-  def "Admin can access releases endpoint"() {
-    given:
-    def token = createTokenWithScope("releases-read")
-    jwtDecoder.decode(*_) >> token
-    def requestBody = new ReleasesRequestPaginated(page: 1, size: 10, artists: [])
-    def request = post(RELEASES)
-        .content(objectMapper.writeValueAsString(requestBody))
-        .contentType(APPLICATION_JSON)
-        .header("Authorization", "Bearer $token.tokenValue")
-
-    when:
-    def result = mockMvc.perform(request).andReturn()
-
-    then:
-    result.response.status == OK.value()
-  }
-
-  def "Admin can access unpaginated releases endpoint"() {
-    given:
-    def token = createTokenWithScope("releases-read-all")
-    jwtDecoder.decode(*_) >> token
-    def requestBody = new ReleasesRequest(artists: [])
+    jwtDecoder.decode(*_) >> RELEASES_READ_ALL_JWT
     def request = post(RELEASES_UNPAGINATED)
-        .content(objectMapper.writeValueAsString(requestBody))
         .contentType(APPLICATION_JSON)
-        .header("Authorization", "Bearer $token.tokenValue")
-    releaseService.findAllUpcomingReleases(*_) >> []
+        .accept(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(body))
+        .header("Authorization", "Bearer $RELEASES_READ_ALL_JWT.tokenValue")
 
     when:
     def result = mockMvc.perform(request).andReturn()
 
     then:
-    result.response.status == OK.value()
+    result.response.status == UNPROCESSABLE_ENTITY.value()
+
+    where:
+    body << [new ReleasesRequest(artists: ARTISTS, dateFrom: null, dateTo: LocalDate.of(2020, 2, 1)),
+             new ReleasesRequest(artists: ARTISTS, dateFrom: LocalDate.of(2020, 1, 1), dateTo: LocalDate.of(2019, 1, 1))]
   }
 
-  def "User cannot access unpaginated releases endpoint"() {
+  @Unroll
+  "getAllReleases: missing request body should return status BAD REQUEST"() {
     given:
-    jwtDecoder.decode(*_) >> USER_JWT
-    def requestBody = new ReleasesRequest(artists: [])
+    jwtDecoder.decode(*_) >> RELEASES_READ_ALL_JWT
     def request = post(RELEASES_UNPAGINATED)
-        .content(objectMapper.writeValueAsString(requestBody))
         .contentType(APPLICATION_JSON)
-        .header("Authorization", "Bearer $USER_JWT.tokenValue")
-    releaseService.findAllUpcomingReleases(*_) >> []
+        .accept(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(body))
+        .header("Authorization", "Bearer $RELEASES_READ_ALL_JWT.tokenValue")
 
     when:
     def result = mockMvc.perform(request).andReturn()
 
     then:
-    result.response.status == FORBIDDEN.value()
+    result.response.status == BAD_REQUEST.value()
+
+    where:
+    body << [null, ""]
   }
 
-  def "User cannot access release update endpoint"() {
+  @Unroll
+  "getPaginatedReleases: faulty request should return status UNPROCESSABLE ENTITY"() {
     given:
-    jwtDecoder.decode(*_) >> USER_JWT
-    def requestBody = new ReleaseUpdateRequest(state: FAULTY)
-    def request = put(UPDATE_RELEASE, 1)
-        .content(objectMapper.writeValueAsString(requestBody))
+    jwtDecoder.decode(*_) >> RELEASES_READ_JWT
+    def request = post(RELEASES)
         .contentType(APPLICATION_JSON)
-        .header("Authorization", "Bearer $USER_JWT.tokenValue")
+        .accept(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(body))
+        .header("Authorization", "Bearer $RELEASES_READ_JWT.tokenValue")
 
     when:
     def result = mockMvc.perform(request).andReturn()
 
     then:
-    result.response.status == FORBIDDEN.value()
+    result.response.status == UNPROCESSABLE_ENTITY.value()
+
+    where:
+    body << [new ReleasesRequestPaginated(artists: ARTISTS, dateFrom: null, dateTo: LocalDate.of(2020, 2, 1), page: 1, size: 10),
+             new ReleasesRequestPaginated(artists: ARTISTS, dateFrom: LocalDate.of(2020, 1, 1),
+                                          dateTo: LocalDate.of(2020, 2, 1), page: 0, size: 10),
+             new ReleasesRequestPaginated(artists: ARTISTS, dateFrom: LocalDate.of(2020, 1, 1),
+                                          dateTo: LocalDate.of(2020, 2, 1), page: 1, size: 0),
+             new ReleasesRequestPaginated(artists: ARTISTS, dateFrom: LocalDate.of(2020, 1, 1),
+                                          dateTo: LocalDate.of(2020, 2, 1), page: 1, size: 51),
+             new ReleasesRequestPaginated(artists: ARTISTS, dateFrom: LocalDate.of(2020, 1, 1), dateTo: LocalDate.of(2019, 1, 1),
+                                          page: 1, size: 10)]
   }
 
-  def "Admin can access release update endpoint"() {
+  @Unroll
+  "getPaginatedReleases: missing request body should return status BAD REQUEST"() {
     given:
-    def token = createTokenWithScope("releases-write")
-    jwtDecoder.decode(*_) >> token
-    def requestBody = new ReleaseUpdateRequest(state: FAULTY)
-    def request = put(UPDATE_RELEASE, 1)
-        .content(objectMapper.writeValueAsString(requestBody))
+    jwtDecoder.decode(*_) >> RELEASES_READ_JWT
+    def request = post(RELEASES)
         .contentType(APPLICATION_JSON)
-        .header("Authorization", "Bearer $token.tokenValue")
+        .accept(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(body))
+        .header("Authorization", "Bearer $RELEASES_READ_JWT.tokenValue")
 
     when:
     def result = mockMvc.perform(request).andReturn()
 
     then:
-    result.response.status == OK.value()
+    result.response.status == BAD_REQUEST.value()
+
+    where:
+    body << [null, ""]
   }
 
-  private Jwt createTokenWithScope(String scope) {
-    Jwt.withTokenValue("token")
-        .header("alg", "none")
-        .claim("scope", scope)
-        .build()
+  def "updateReleaseState: should return UNPROCESSABLE ENTITY for missing state"() {
+    given:
+    jwtDecoder.decode(*_) >> RELEASES_WRITE_JWT
+    def request = put(UPDATE_RELEASE, 1)
+        .contentType(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(new ReleaseUpdateRequest(state: null)))
+        .header("Authorization", "Bearer $RELEASES_WRITE_JWT.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == UNPROCESSABLE_ENTITY.value()
+  }
+
+  def "updateReleaseState: should return NOT FOUND for wrong release id"() {
+    given:
+    jwtDecoder.decode(*_) >> RELEASES_WRITE_JWT
+    def request = put(UPDATE_RELEASE, 0)
+        .contentType(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(new ReleaseUpdateRequest(FAULTY)))
+        .header("Authorization", "Bearer $RELEASES_WRITE_JWT.tokenValue")
+    releaseService.updateReleaseState(*_) >> { throw new ResourceNotFoundException("not found") }
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == NOT_FOUND.value()
+  }
+
+  @Unroll
+  "updateReleaseState: should return BAD REQUEST for missing request body"() {
+    given:
+    jwtDecoder.decode(*_) >> RELEASES_WRITE_JWT
+    def request = put(UPDATE_RELEASE, 1)
+        .contentType(APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(body))
+        .header("Authorization", "Bearer $RELEASES_WRITE_JWT.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == BAD_REQUEST.value()
+
+    where:
+    body << [null, ""]
   }
 }

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerSecurityIT.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ReleasesRestControllerSecurityIT.groovy
@@ -1,0 +1,146 @@
+package rocks.metaldetector.butler.web.rest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.web.servlet.MockMvc
+import rocks.metaldetector.butler.service.release.ReleaseService
+import rocks.metaldetector.butler.testutil.WithIntegrationTestConfig
+import rocks.metaldetector.butler.web.api.ReleaseUpdateRequest
+import rocks.metaldetector.butler.web.api.ReleasesRequest
+import rocks.metaldetector.butler.web.api.ReleasesRequestPaginated
+import spock.lang.Specification
+
+import static org.springframework.http.HttpStatus.FORBIDDEN
+import static org.springframework.http.HttpStatus.OK
+import static org.springframework.http.MediaType.APPLICATION_JSON
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import static rocks.metaldetector.butler.persistence.domain.release.ReleaseEntityState.FAULTY
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASES
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASES_UNPAGINATED
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.UPDATE_RELEASE
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ReleasesRestControllerSecurityIT extends Specification implements WithIntegrationTestConfig {
+
+  private final Jwt OTHER_SCOPE_JWT = createTokenWithScope("other-scope")
+
+  @Autowired
+  MockMvc mockMvc
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @SpringBean
+  ReleaseService releaseService = Mock(ReleaseService)
+
+  @SpringBean
+  JwtDecoder jwtDecoder = Mock(JwtDecoder)
+
+  def "Scope 'releases-read' can access releases endpoint"() {
+    given:
+    def token = createTokenWithScope("releases-read")
+    jwtDecoder.decode(*_) >> token
+    def requestBody = new ReleasesRequestPaginated(page: 1, size: 10, artists: [])
+    def request = post(RELEASES)
+        .content(objectMapper.writeValueAsString(requestBody))
+        .contentType(APPLICATION_JSON)
+        .header("Authorization", "Bearer $token.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == OK.value()
+  }
+
+  def "Other scopes cannot access releases endpoint"() {
+    given:
+    jwtDecoder.decode(*_) >> OTHER_SCOPE_JWT
+    def requestBody = new ReleasesRequestPaginated(page: 1, size: 10, artists: [])
+    def request = post(RELEASES)
+        .content(objectMapper.writeValueAsString(requestBody))
+        .contentType(APPLICATION_JSON)
+        .header("Authorization", "Bearer $OTHER_SCOPE_JWT.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == FORBIDDEN.value()
+  }
+
+  def "Scope 'releases-read-all' can access unpaginated releases endpoint"() {
+    given:
+    def token = createTokenWithScope("releases-read-all")
+    jwtDecoder.decode(*_) >> token
+    def requestBody = new ReleasesRequest(artists: [])
+    def request = post(RELEASES_UNPAGINATED)
+        .content(objectMapper.writeValueAsString(requestBody))
+        .contentType(APPLICATION_JSON)
+        .header("Authorization", "Bearer $token.tokenValue")
+    releaseService.findAllUpcomingReleases(*_) >> []
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == OK.value()
+  }
+
+  def "Other scopes cannot access unpaginated releases endpoint"() {
+    given:
+    jwtDecoder.decode(*_) >> OTHER_SCOPE_JWT
+    def requestBody = new ReleasesRequest(artists: [])
+    def request = post(RELEASES_UNPAGINATED)
+        .content(objectMapper.writeValueAsString(requestBody))
+        .contentType(APPLICATION_JSON)
+        .header("Authorization", "Bearer $OTHER_SCOPE_JWT.tokenValue")
+    releaseService.findAllUpcomingReleases(*_) >> []
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == FORBIDDEN.value()
+  }
+
+  def "Scope 'releases-write' can access release update endpoint"() {
+    given:
+    def token = createTokenWithScope("releases-write")
+    jwtDecoder.decode(*_) >> token
+    def requestBody = new ReleaseUpdateRequest(state: FAULTY)
+    def request = put(UPDATE_RELEASE, 1)
+        .content(objectMapper.writeValueAsString(requestBody))
+        .contentType(APPLICATION_JSON)
+        .header("Authorization", "Bearer $token.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == OK.value()
+  }
+
+  def "Other scopes cannot access release update endpoint"() {
+    given:
+    jwtDecoder.decode(*_) >> OTHER_SCOPE_JWT
+    def requestBody = new ReleaseUpdateRequest(state: FAULTY)
+    def request = put(UPDATE_RELEASE, 1)
+        .content(objectMapper.writeValueAsString(requestBody))
+        .contentType(APPLICATION_JSON)
+        .header("Authorization", "Bearer $OTHER_SCOPE_JWT.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == FORBIDDEN.value()
+  }
+}

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/RestExceptionHandlerIT.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/RestExceptionHandlerIT.groovy
@@ -1,0 +1,106 @@
+package rocks.metaldetector.butler.web.rest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.web.servlet.MockMvc
+import rocks.metaldetector.butler.service.release.ReleaseService
+import rocks.metaldetector.butler.testutil.WithIntegrationTestConfig
+import rocks.metaldetector.butler.web.api.ReleasesRequestPaginated
+import spock.lang.Specification
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE
+import static org.springframework.http.MediaType.APPLICATION_JSON
+import static org.springframework.http.MediaType.APPLICATION_XHTML_XML
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASES
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RestExceptionHandlerIT extends Specification implements WithIntegrationTestConfig {
+
+  private final Jwt READ_JWT = createTokenWithScope("releases-read")
+
+  @Autowired
+  MockMvc mockMvc
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @SpringBean
+  JwtDecoder jwtDecoder = Mock(JwtDecoder)
+
+  @SpringBean
+  ReleaseService releaseService = Mock(ReleaseService)
+
+  def "invalid request method returns 405"() {
+    given:
+    jwtDecoder.decode(*_) >> READ_JWT
+    def request = get(RELEASES)
+        .contentType(APPLICATION_JSON)
+        .header("Authorization", "Bearer $READ_JWT.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == METHOD_NOT_ALLOWED.value()
+  }
+
+  def "invalid media type returns 415"() {
+    given:
+    jwtDecoder.decode(*_) >> READ_JWT
+    def requestBody = new ReleasesRequestPaginated(page: 1, size: 10, artists: [])
+    def request = post(RELEASES)
+        .content(objectMapper.writeValueAsString(requestBody))
+        .contentType(APPLICATION_XHTML_XML)
+        .header("Authorization", "Bearer $READ_JWT.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == UNSUPPORTED_MEDIA_TYPE.value()
+  }
+
+  def "invalid request returns 422"() {
+    given:
+    jwtDecoder.decode(*_) >> READ_JWT
+    def requestBody = new ReleasesRequestPaginated(page: -1, size: 10, artists: [])
+    def request = post(RELEASES)
+        .content(objectMapper.writeValueAsString(requestBody))
+        .contentType(APPLICATION_JSON)
+        .header("Authorization", "Bearer $READ_JWT.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == UNPROCESSABLE_ENTITY.value()
+  }
+
+  def "other errors return 500"() {
+    given:
+    jwtDecoder.decode(*_) >> READ_JWT
+    def requestBody = new ReleasesRequestPaginated(page: 1, size: 10, artists: [])
+    def request = post(RELEASES)
+        .content(objectMapper.writeValueAsString(requestBody))
+        .contentType(APPLICATION_JSON)
+        .header("Authorization", "Bearer $READ_JWT.tokenValue")
+    releaseService.findAllUpcomingReleases(*_) >> { throw new RuntimeException("boom") }
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == INTERNAL_SERVER_ERROR.value()
+  }
+}

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/LocalCoverPersistenceService.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/LocalCoverPersistenceService.groovy
@@ -31,7 +31,7 @@ class LocalCoverPersistenceService implements CoverPersistenceService {
       return "$RELEASE_IMAGES?id=$localFileName"
     }
     catch (Exception e) {
-      log.error("Could not persist cover from '${coverUrl.toString()}'", e)
+      log.error("Could not persist cover from '$coverUrl'", e)
       return null
     }
   }
@@ -52,7 +52,7 @@ class LocalCoverPersistenceService implements CoverPersistenceService {
     log.info("Transfer '${coverUrl.toExternalForm()}' to '${localFilePath}'")
     long bytesTransferred = fileTransferService.transferFileFromUrl(coverUrl, localFilePath)
     if (bytesTransferred <= 0) {
-      throw new RuntimeException("no bytes are transferred from ${coverUrl.toString()}")
+      throw new RuntimeException("no bytes are transferred from '$coverUrl'")
     }
   }
 }

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/LocalCoverPersistenceService.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/LocalCoverPersistenceService.groovy
@@ -31,7 +31,7 @@ class LocalCoverPersistenceService implements CoverPersistenceService {
       return "$RELEASE_IMAGES?id=$localFileName"
     }
     catch (Exception e) {
-      log.error("Could not persist cover from '$coverUrl'", e)
+      log.error("Could not persist cover from '${coverUrl.toString()}'", e)
       return null
     }
   }
@@ -52,7 +52,7 @@ class LocalCoverPersistenceService implements CoverPersistenceService {
     log.info("Transfer '${coverUrl.toExternalForm()}' to '${localFilePath}'")
     long bytesTransferred = fileTransferService.transferFileFromUrl(coverUrl, localFilePath)
     if (bytesTransferred <= 0) {
-      throw new RuntimeException("no bytes are transferred from '$coverUrl'")
+      throw new RuntimeException("no bytes are transferred from '${coverUrl.toString()}'")
     }
   }
 }

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/LocalCoverPersistenceService.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/LocalCoverPersistenceService.groovy
@@ -31,7 +31,7 @@ class LocalCoverPersistenceService implements CoverPersistenceService {
       return "$RELEASE_IMAGES?id=$localFileName"
     }
     catch (Exception e) {
-      log.error("Could not persist cover from '${coverUrl}'", e)
+      log.error("Could not persist cover from '${coverUrl.toString()}'", e)
       return null
     }
   }
@@ -52,7 +52,7 @@ class LocalCoverPersistenceService implements CoverPersistenceService {
     log.info("Transfer '${coverUrl.toExternalForm()}' to '${localFilePath}'")
     long bytesTransferred = fileTransferService.transferFileFromUrl(coverUrl, localFilePath)
     if (bytesTransferred <= 0) {
-      throw new RuntimeException("no bytes are transferred from $coverUrl")
+      throw new RuntimeException("no bytes are transferred from ${coverUrl.toString()}")
     }
   }
 }

--- a/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/LocalCoverPersistenceServiceTest.groovy
+++ b/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/LocalCoverPersistenceServiceTest.groovy
@@ -16,7 +16,6 @@ class LocalCoverPersistenceServiceTest extends Specification {
     def url = GroovyMock(URL) {
       getPath() >> "foo.jpg"
     }
-
     underTest.fileTransferService.transferFileFromUrl(*_) >> 1
 
     when:
@@ -27,5 +26,20 @@ class LocalCoverPersistenceServiceTest extends Specification {
 
     and:
     result.endsWith("jpg")
+  }
+
+  def "null is returned if empty file is created"() {
+    given:
+    def targetFolder = "path/to/target"
+    def url = GroovyMock(URL) {
+      getPath() >> "foo.jpg"
+    }
+    underTest.fileTransferService.transferFileFromUrl(*_) >> 0
+
+    when:
+    def result = underTest.persistCover(url, targetFolder)
+
+    then:
+    !result
   }
 }

--- a/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/LocalFileTransferServiceTest.groovy
+++ b/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/LocalFileTransferServiceTest.groovy
@@ -1,0 +1,42 @@
+package rocks.metaldetector.butler.supplier.infrastructure.cover
+
+import spock.lang.Specification
+
+import static org.codehaus.groovy.runtime.ResourceGroovyMethods.write
+
+class LocalFileTransferServiceTest extends Specification {
+
+  LocalFileTransferService underTest = new LocalFileTransferService()
+  File file
+
+  void setup() {
+    file = new File("classpath:test.txt")
+    write(file, "someText")
+  }
+
+  void cleanup() {
+    try {
+      new File("classpath:test.txt").delete()
+    }
+    catch (Exception ignored) {}
+    try {
+      new File("classpath:test2.txt").delete()
+    }
+    catch (Exception ignored) {}
+  }
+
+  def "inputStream is written"() {
+    given:
+    def mockUrl = GroovyMock(URL)
+    def inputStream = file.newInputStream()
+
+    when:
+    def result = underTest.transferFileFromUrl(mockUrl, "classpath:test2.txt")
+
+    then:
+    1 * mockUrl.openStream() >> inputStream
+
+    and:
+    result > 0
+  }
+}

--- a/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/S3PersistenceServiceTest.groovy
+++ b/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/cover/S3PersistenceServiceTest.groovy
@@ -4,7 +4,6 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.ObjectMetadata
 import spock.lang.Specification
-import spock.lang.Unroll
 
 import static rocks.metaldetector.butler.supplier.infrastructure.cover.S3PersistenceService.PATH
 
@@ -78,8 +77,7 @@ class S3PersistenceServiceTest extends Specification {
     })
   }
 
-  @Unroll
-  "if upload fails with 'FileNotFoundException' null is returned"() {
+  def "if upload fails with 'FileNotFoundException' null is returned"() {
     given:
     underTest.amazonS3Client.putObject(*_) >> { throw new FileNotFoundException() }
 


### PR DESCRIPTION
This started with me wanting to improve code coverage a bit and ended with rewriting our api error handling 😅 

We often did not use Bad Request vs. Unprosessable Entity correctly. Also the RestExceptionHandler was not used correctly everywhere and the IllegalArgumentException we used in some placed should really be a custom ResourceNotFound (like in the Detector).
A bigger question mark stays with the `ReleaseCoverRestController` for me... I had the feeling that it is not really working the way I expected for a while, but latest with the switch to OAuth something is off.. I always get a "Full Authentication required" message when trying to access images. Which makes sense as it is configured that way in the `SecurityConfig`. There is even a token sent, but that is the Detector's token that the Butler does not know 🤔 And we cannot just put "hasScope" there as we do not call the auth service before accessing images. Could you please test locally if this Controller still works for you? Maybe even before this PR.
Another thing is the IntegrationTest for this controller. I just couldn't get it working, although everything is _exactly_ the same like in the ReleasesRestControllerIT... As this only concerns local development I just commented it out for now.