### PR TITLE
allow anonymous access on local release image endpoint

### DIFF
--- a/app/src/main/groovy/rocks/metaldetector/butler/config/security/SecurityConfig.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/config/security/SecurityConfig.groovy
@@ -6,9 +6,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 
+import static org.springframework.http.HttpMethod.GET
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.AntPattern.ACTUATOR_ENDPOINTS
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.AntPattern.REST_ENDPOINTS
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASE_IMAGES
 
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
@@ -24,6 +26,7 @@ class SecurityConfig extends WebSecurityConfigurerAdapter {
     http.exceptionHandling()
         .and().authorizeRequests()
         .antMatchers(ACTUATOR_ENDPOINTS).permitAll()
+        .antMatchers(GET, RELEASE_IMAGES).permitAll()
         .anyRequest().authenticated()
     http.oauth2ResourceServer().authenticationEntryPoint(jwtAuthenticationEntryPoint)
         .jwt()


### PR DESCRIPTION
The `ReleaseCoverRestController` is only used on default profile and returns the image from local filesystem as multimedia resource. The frontend directly calls for example `http://butler.com/rest/v1/releases/image/1234-1234-1234-1234` in img src. 

I thought about creating a separate SecurityConfig for the default profile as well, but that was too over-engineered for a single endpoint that is only available locally