### PR TITLE
Better config for github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: Continous Integration
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,5 +26,5 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Execute gradle task 'bootJar' and 'publish'
-        run: ./gradlew clean bootJar publish --no-daemon --info --stacktrace
+      - name: Execute gradle task 'build' and 'publish'
+        run: ./gradlew clean build publish --no-daemon --info --stacktrace


### PR DESCRIPTION
Currently CI (= clean build) runs on push to master and on PR. The docker task (= clean bootJar, so no tests) runs on push to master. If we want to have all tests run after pushing to master (which I think makes sense) it sounds smarter to me to run the clean build when building the docker image (instead of using only bootJar). If anything fails, then building the image would fail and it would not be pushed to docker hub. This way we are sure that all tests are run if for example for whatever reason code is pushed to master without a PR.