### PR TITLE
Endpoint for release statistics added

### DIFF
--- a/app/src/main/groovy/rocks/metaldetector/butler/config/security/SecurityConfig.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/config/security/SecurityConfig.groovy
@@ -16,6 +16,7 @@ import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.IMPOR
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASES
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASES_UNPAGINATED
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASE_IMAGES
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.STATISTICS
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.UPDATE_RELEASE
 
 @Configuration
@@ -39,6 +40,7 @@ class SecurityConfig {
               .requestMatchers(UPDATE_RELEASE).hasAuthority("SCOPE_releases-write")
               .requestMatchers(RELEASES_UNPAGINATED).hasAuthority("SCOPE_releases-read-all")
               .requestMatchers(IMPORT_JOB, COVER_JOB).hasAuthority("SCOPE_import")
+              .requestMatchers(STATISTICS).hasAuthority("SCOPE_statistics")
               .anyRequest().denyAll()
         }
         .oauth2ResourceServer {

--- a/app/src/main/groovy/rocks/metaldetector/butler/service/statistics/StatisticsService.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/service/statistics/StatisticsService.groovy
@@ -1,0 +1,35 @@
+package rocks.metaldetector.butler.service.statistics
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
+import rocks.metaldetector.butler.web.api.ReleaseInfo
+
+import java.time.LocalDate
+import java.time.YearMonth
+
+import static rocks.metaldetector.butler.persistence.domain.release.ReleaseEntityState.DEMO
+import static rocks.metaldetector.butler.persistence.domain.release.ReleaseEntityState.DUPLICATE
+
+@Service
+class StatisticsService {
+
+  @Autowired
+  ReleaseRepository releaseRepository
+
+  @Transactional(readOnly = true)
+  ReleaseInfo getReleaseInfo() {
+    def releasesPerMonth = releaseRepository.groupReleasesByYearAndMonth()
+        .collectEntries { new MapEntry(YearMonth.of(it.releaseYear, it.releaseMonth), it.releases) } as TreeMap<YearMonth, Integer>
+    def totalReleases = (releasesPerMonth.values().sum() ?: 0) as long
+    def upcomingReleases = releaseRepository.countByReleaseDateAfterAndStateNot(LocalDate.now(), DEMO)
+    def duplicates = releaseRepository.countByState(DUPLICATE)
+
+    return new ReleaseInfo(releasesPerMonth: releasesPerMonth,
+                           totalReleases: totalReleases,
+                           upcomingReleases: upcomingReleases,
+                           releasesThisMonth: releasesPerMonth[YearMonth.now()] ?: 0,
+                           duplicates: duplicates)
+  }
+}

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/api/ReleaseInfo.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/api/ReleaseInfo.groovy
@@ -1,0 +1,12 @@
+package rocks.metaldetector.butler.web.api
+
+import java.time.YearMonth
+
+class ReleaseInfo {
+
+  Map<YearMonth, Integer> releasesPerMonth
+  long totalReleases
+  int upcomingReleases
+  int releasesThisMonth
+  int duplicates
+}

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/api/StatisticsResponse.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/api/StatisticsResponse.groovy
@@ -1,0 +1,10 @@
+package rocks.metaldetector.butler.web.api
+
+import groovy.transform.Canonical
+
+@Canonical
+class StatisticsResponse {
+
+  ReleaseInfo releaseInfo
+
+}

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/rest/StatisticsRestController.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/rest/StatisticsRestController.groovy
@@ -1,0 +1,26 @@
+package rocks.metaldetector.butler.web.rest
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import rocks.metaldetector.butler.service.statistics.StatisticsService
+import rocks.metaldetector.butler.web.api.ReleaseInfo
+import rocks.metaldetector.butler.web.api.StatisticsResponse
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.STATISTICS
+
+@RestController
+class StatisticsRestController {
+
+  @Autowired
+  StatisticsService statisticsService
+
+  @GetMapping(path = STATISTICS, produces = APPLICATION_JSON_VALUE)
+  ResponseEntity<StatisticsResponse> getStatistics() {
+    ReleaseInfo releaseInfo = statisticsService.getReleaseInfo()
+    StatisticsResponse response = new StatisticsResponse(releaseInfo: releaseInfo)
+    return ResponseEntity.ok(response)
+  }
+}

--- a/app/src/test/groovy/rocks/metaldetector/butler/service/statistics/StatisticsServiceTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/service/statistics/StatisticsServiceTest.groovy
@@ -1,0 +1,146 @@
+package rocks.metaldetector.butler.service.statistics
+
+import rocks.metaldetector.butler.persistence.domain.release.ReleasePerMonth
+import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
+import spock.lang.Specification
+
+import java.time.LocalDate
+import java.time.YearMonth
+
+import static rocks.metaldetector.butler.persistence.domain.release.ReleaseEntityState.DEMO
+import static rocks.metaldetector.butler.persistence.domain.release.ReleaseEntityState.DUPLICATE
+
+class StatisticsServiceTest extends Specification {
+
+  StatisticsService underTest = new StatisticsService(releaseRepository: Mock(ReleaseRepository))
+
+  def "releaseRepository is called for grouped releases"() {
+    given:
+    underTest.releaseRepository.countByState(*_) >> 0
+    underTest.releaseRepository.countByReleaseDateAfterAndStateNot(*_) >> 0
+
+    when:
+    underTest.getReleaseInfo()
+
+    then:
+    1 * underTest.releaseRepository.groupReleasesByYearAndMonth() >> []
+  }
+
+  def "releaseRepository is called to count duplicates"() {
+    given:
+    underTest.releaseRepository.countByReleaseDateAfterAndStateNot(*_) >> 0
+    underTest.releaseRepository.groupReleasesByYearAndMonth() >> []
+
+    when:
+    underTest.getReleaseInfo()
+
+    then:
+    1 * underTest.releaseRepository.countByState(DUPLICATE) >> 0
+  }
+
+  def "releaseRepository is called to count upcoming releases"() {
+    given:
+    underTest.releaseRepository.countByState(*_) >> 0
+    underTest.releaseRepository.groupReleasesByYearAndMonth() >> []
+
+    GroovyMock(LocalDate, global: true)
+    def releaseDate = LocalDate.of(2020, 1, 1)
+    LocalDate.now() >> releaseDate
+
+    when:
+    underTest.getReleaseInfo()
+
+    then:
+    1 * underTest.releaseRepository.countByReleaseDateAfterAndStateNot(releaseDate, DEMO) >> 0
+  }
+
+  def "releasesPerMonth are returned"() {
+    given:
+    underTest.releaseRepository.countByState(*_) >> 0
+    underTest.releaseRepository.countByReleaseDateAfterAndStateNot(*_) >> 0
+
+    def releasePerMonth1 = Mock(ReleasePerMonth)
+    def releasePerMonth2 = Mock(ReleasePerMonth)
+    releasePerMonth1.releaseYear >> 2020
+    releasePerMonth2.releaseYear >> 2020
+    releasePerMonth1.releaseMonth >> 1
+    releasePerMonth2.releaseMonth >> 2
+    releasePerMonth1.releases >> 3
+    releasePerMonth2.releases >> 6
+    underTest.releaseRepository.groupReleasesByYearAndMonth() >> [releasePerMonth1, releasePerMonth2]
+
+    when:
+    def result = underTest.getReleaseInfo()
+
+    then:
+    result.releasesPerMonth == [(YearMonth.of(2020, 1)): 3,
+                                (YearMonth.of(2020, 2)): 6]
+  }
+
+  def "totalReleases are returned"() {
+    given:
+    underTest.releaseRepository.countByState(*_) >> 0
+    underTest.releaseRepository.countByReleaseDateAfterAndStateNot(*_) >> 0
+
+    def releasePerMonth1 = Mock(ReleasePerMonth)
+    def releasePerMonth2 = Mock(ReleasePerMonth)
+    releasePerMonth1.releaseYear >> 2020
+    releasePerMonth2.releaseYear >> 2020
+    releasePerMonth1.releaseMonth >> 1
+    releasePerMonth2.releaseMonth >> 2
+    releasePerMonth1.releases >> 3
+    releasePerMonth2.releases >> 6
+    underTest.releaseRepository.groupReleasesByYearAndMonth() >> [releasePerMonth1, releasePerMonth2]
+
+    when:
+    def result = underTest.getReleaseInfo()
+
+    then:
+    result.totalReleases == 9
+  }
+
+  def "upcomingReleases are returned"() {
+    given:
+    underTest.releaseRepository.countByState(*_) >> 0
+    underTest.releaseRepository.groupReleasesByYearAndMonth() >> []
+    underTest.releaseRepository.countByReleaseDateAfterAndStateNot(*_) >> 6
+
+    when:
+    def result = underTest.getReleaseInfo()
+
+    then:
+    result.upcomingReleases == 6
+  }
+
+  def "releasesThisMonth are returned"() {
+    given:
+    underTest.releaseRepository.countByState(*_) >> 0
+    underTest.releaseRepository.countByReleaseDateAfterAndStateNot(*_) >> 0
+
+    def thisMonth = LocalDate.now()
+    def releasePerMonth = Mock(ReleasePerMonth)
+    releasePerMonth.releaseYear >> thisMonth.year
+    releasePerMonth.releaseMonth >> thisMonth.month.value
+    releasePerMonth.releases >> 6
+    underTest.releaseRepository.groupReleasesByYearAndMonth() >> [releasePerMonth]
+
+    when:
+    def result = underTest.getReleaseInfo()
+
+    then:
+    result.releasesThisMonth == 6
+  }
+
+  def "duplicates are returned"() {
+    given:
+    underTest.releaseRepository.countByState(*_) >> 6
+    underTest.releaseRepository.countByReleaseDateAfterAndStateNot(*_) >> 0
+    underTest.releaseRepository.groupReleasesByYearAndMonth() >> []
+
+    when:
+    def result = underTest.getReleaseInfo()
+
+    then:
+    result.duplicates == 6
+  }
+}

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/StatisticsRestControllerSecurityIntegrationTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/StatisticsRestControllerSecurityIntegrationTest.groovy
@@ -1,0 +1,69 @@
+package rocks.metaldetector.butler.web.rest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import rocks.metaldetector.butler.service.statistics.StatisticsService
+import rocks.metaldetector.butler.testutil.WithIntegrationTestConfig
+import spock.lang.Specification
+
+import static org.springframework.http.HttpStatus.FORBIDDEN
+import static org.springframework.http.HttpStatus.OK
+import static org.springframework.http.MediaType.APPLICATION_JSON
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.STATISTICS
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ContextConfiguration
+class StatisticsRestControllerSecurityIntegrationTest extends Specification implements WithIntegrationTestConfig {
+
+  private final Jwt OTHER_SCOPE_JWT = createTokenWithScope("other-scope")
+
+  @Autowired
+  MockMvc mockMvc
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @SpringBean
+  StatisticsService statisticService = Mock(StatisticsService)
+
+  @SpringBean
+  JwtDecoder jwtDecoder = Mock(JwtDecoder)
+
+  def "Scope 'statistics' can access statistics endpoint"() {
+    given:
+    def token = createTokenWithScope("statistics")
+    jwtDecoder.decode(*_) >> token
+    def request = get(STATISTICS)
+        .accept(APPLICATION_JSON)
+        .header("Authorization", "Bearer $token.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == OK.value()
+  }
+
+  def "Other scopes cannot access statistics endpoint"() {
+    given:
+    jwtDecoder.decode(*_) >> OTHER_SCOPE_JWT
+    def request = get(STATISTICS)
+        .accept(APPLICATION_JSON)
+        .header("Authorization", "Bearer $OTHER_SCOPE_JWT.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == FORBIDDEN.value()
+  }
+}

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/StatisticsRestControllerTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/StatisticsRestControllerTest.groovy
@@ -1,0 +1,41 @@
+package rocks.metaldetector.butler.web.rest
+
+import rocks.metaldetector.butler.service.statistics.StatisticsService
+import rocks.metaldetector.butler.web.api.ReleaseInfo
+import rocks.metaldetector.butler.web.api.StatisticsResponse
+import spock.lang.Specification
+
+import static org.springframework.http.HttpStatus.OK
+
+class StatisticsRestControllerTest extends Specification {
+
+  StatisticsRestController underTest = new StatisticsRestController(statisticsService: Mock(StatisticsService))
+
+  def "getting statistics should call statisticsService"() {
+    when:
+    underTest.getStatistics()
+
+    then:
+    1 * underTest.statisticsService.getReleaseInfo() >> new ReleaseInfo()
+  }
+
+  def "getting statistics should return statisticsResponse"() {
+    given:
+    def releaseInfo = new ReleaseInfo(upcomingReleases: 666)
+    underTest.statisticsService.getReleaseInfo() >> releaseInfo
+
+    when:
+    def result = underTest.getStatistics()
+
+    then:
+    result.body == new StatisticsResponse(releaseInfo: releaseInfo)
+  }
+
+  def "getting statistics should return ok"() {
+    when:
+    def result = underTest.getStatistics()
+
+    then:
+    result.statusCode == OK
+  }
+}

--- a/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/release/ReleasePerMonth.groovy
+++ b/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/release/ReleasePerMonth.groovy
@@ -1,0 +1,8 @@
+package rocks.metaldetector.butler.persistence.domain.release
+
+interface ReleasePerMonth {
+
+  Integer getReleaseYear()
+  Integer getReleaseMonth()
+  Integer getReleases()
+}

--- a/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/release/ReleaseRepository.groovy
+++ b/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/release/ReleaseRepository.groovy
@@ -35,6 +35,13 @@ interface ReleaseRepository extends JpaRepository<ReleaseEntity, Long> {
 
   Optional<ReleaseEntity> findById(long id)
 
+  @Query(value = "select extract(YEAR from r.release_date) as releaseYear, extract(MONTH from r.release_date) as releaseMonth, count(*) as releases from releases r where r.state not like 'DEMO' group by releaseYear, releaseMonth order by releaseMonth, releaseYear", nativeQuery = true)
+  List<ReleasePerMonth> groupReleasesByYearAndMonth()
+
+  Long countByReleaseDateAfterAndStateNot(LocalDate releaseDate, ReleaseEntityState state)
+
+  Long countByState(ReleaseEntityState state)
+
   boolean existsByArtistIgnoreCaseAndAlbumTitleIgnoreCaseAndReleaseDate(String artist, String albumTitle, LocalDate releaseDate)
 
   void deleteByReleaseDetailsUrl(String releaseDetailsUrl)

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/Endpoints.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/Endpoints.groovy
@@ -8,6 +8,7 @@ class Endpoints {
   public static final String COVER_JOB            = "/rest/v1/releases/cover-reload"
   public static final String RELEASE_IMAGES       = "/rest/v1/releases/images"
   public static final String IMPORT_JOB           = "/rest/v1/releases/import"
+  public static final String STATISTICS           = "/rest/v1/releases/statistics"
 
   static class AntPattern {
 


### PR DESCRIPTION
I added a new scope (see [here](https://github.com/MetalDetectorRocks/metal-detector-auth/pull/169)) because it felt weird to use any of the existing ones.