### PR TITLE
import in batches

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -76,7 +76,8 @@ httpclient:
   useragent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36
 
 concurrency:
-  release-import-pool-size: 4
+  release-import-pool-size: 3
+  throttling-in-seconds: 5
 
 aws:
   access-key: ${AWS_ACCESS_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,14 +47,14 @@ services:
 
   auth-app:
     container_name: butler-auth-app
-    image: metaldetector/metal-detector-auth:20230226T085029
+    image: metaldetectorrocks/metal-detector-auth:20230925T173111
     environment:
       SERVER_PORT: 9000
       DATASOURCE_URL: jdbc:postgresql://auth-db:5432/metal-detector-auth
       DATASOURCE_USERNAME: postgres
       DATASOURCE_PASSWORD: secret
-      AUTHORIZATION_SERVER_PRIVATE_KEY:
-      AUTHORIZATION_SERVER_PUBLIC_KEY:
+      AUTHORIZATION_SERVER_PRIVATE_KEY: ''
+      AUTHORIZATION_SERVER_PUBLIC_KEY: ''
       METAL_DETECTOR_USER_CLIENT_ID: metal-detector-user
       METAL_DETECTOR_USER_CLIENT_SECRET: userSecret
       METAL_DETECTOR_ADMIN_CLIENT_ID: metal-detector-admin

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/CoverDownloadTask.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/CoverDownloadTask.groovy
@@ -3,7 +3,7 @@ package rocks.metaldetector.butler.supplier.infrastructure.importjob
 import rocks.metaldetector.butler.persistence.domain.release.ReleaseEntity
 import rocks.metaldetector.butler.supplier.infrastructure.cover.CoverService
 
-class CoverTransferTask implements Runnable {
+class CoverDownloadTask implements Runnable {
 
   ReleaseEntity releaseEntity
   CoverService coverService

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/ParallelCoverDownloader.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/ParallelCoverDownloader.groovy
@@ -1,0 +1,36 @@
+package rocks.metaldetector.butler.supplier.infrastructure.importjob
+
+import groovy.util.logging.Slf4j
+import jakarta.transaction.Transactional
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.stereotype.Service
+import rocks.metaldetector.butler.persistence.domain.release.ReleaseEntity
+import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
+
+import java.util.concurrent.Future
+import java.util.function.Function
+
+@Slf4j
+@Service
+class ParallelCoverDownloader {
+
+  @Autowired
+  ThreadPoolTaskExecutor threadPoolTaskExecutor
+
+  @Autowired
+  ReleaseRepository releaseRepository
+
+  @Transactional
+  List<ReleaseEntity> downloadAndSave(List<ReleaseEntity> releaseBatch, Function<ReleaseEntity, Runnable> coverDownloadTask) {
+    List<Future> futures = []
+
+    releaseBatch.each {
+      releaseEntity -> futures << threadPoolTaskExecutor.submit(coverDownloadTask.apply(releaseEntity))
+    }.collect()
+
+    futures*.get()
+    releaseRepository.saveAll(releaseBatch)
+    return releaseBatch
+  }
+}

--- a/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/CoverDownloadTaskTest.groovy
+++ b/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/CoverDownloadTaskTest.groovy
@@ -6,9 +6,9 @@ import spock.lang.Specification
 
 import java.time.LocalDate
 
-class CoverTransferTaskTest extends Specification {
+class CoverDownloadTaskTest extends Specification {
 
-  CoverTransferTask underTest = new CoverTransferTask(
+  CoverDownloadTask underTest = new CoverDownloadTask(
       coverService: Mock(CoverService),
       releaseEntity: Mock(ReleaseEntity)
   )

--- a/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/ParallelCoverDownloaderTest.groovy
+++ b/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/ParallelCoverDownloaderTest.groovy
@@ -1,0 +1,49 @@
+package rocks.metaldetector.butler.supplier.infrastructure.importjob
+
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
+import spock.lang.Specification
+
+import static rocks.metaldetector.butler.supplier.infrastructure.DtoFactory.ReleaseEntityFactory.createReleaseEntity
+
+class ParallelCoverDownloaderTest extends Specification {
+
+  ParallelCoverDownloader underTest = new ParallelCoverDownloader(
+      threadPoolTaskExecutor: Mock(ThreadPoolTaskExecutor),
+      releaseRepository: Mock(ReleaseRepository)
+  )
+
+  def "should submit CoverDownloadTask for each release"() {
+    given:
+    def release1 = createReleaseEntity("a")
+    def release2 = createReleaseEntity("b")
+    def releaseEntities = [release1, release2]
+
+    when:
+    underTest.downloadAndSave(releaseEntities, release -> new CoverDownloadTask(releaseEntity: release))
+
+    then:
+    1 * underTest.threadPoolTaskExecutor.submit({
+      args -> args instanceof CoverDownloadTask && args.releaseEntity == release1
+    })
+
+    and:
+    1 * underTest.threadPoolTaskExecutor.submit({
+      args -> args instanceof CoverDownloadTask && args.releaseEntity == release2
+    })
+  }
+
+  def "should call release repository to save all new releases"() {
+    given:
+    def releaseEntities = [
+        createReleaseEntity("a"),
+        createReleaseEntity("b")
+    ]
+
+    when:
+    underTest.downloadAndSave(releaseEntities, release -> () -> {})
+
+    then:
+    1 * underTest.releaseRepository.saveAll(releaseEntities)
+  }
+}

--- a/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/MetalArchivesReleaseImportUtils.groovy
+++ b/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/MetalArchivesReleaseImportUtils.groovy
@@ -1,0 +1,10 @@
+package rocks.metaldetector.butler.supplier.metalarchives
+
+import java.util.concurrent.TimeUnit
+
+trait MetalArchivesReleaseImportUtils {
+
+  void throttle() {
+    TimeUnit.SECONDS.sleep(5)
+  }
+}

--- a/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/MetalArchivesReleaseImportUtils.groovy
+++ b/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/MetalArchivesReleaseImportUtils.groovy
@@ -1,10 +1,10 @@
 package rocks.metaldetector.butler.supplier.metalarchives
 
-import java.util.concurrent.TimeUnit
+import static java.util.concurrent.TimeUnit.SECONDS
 
 trait MetalArchivesReleaseImportUtils {
 
-  void throttle() {
-    TimeUnit.SECONDS.sleep(5)
+  void throttle(long throttlingInSeconds) {
+    SECONDS.sleep(throttlingInSeconds)
   }
 }

--- a/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/MetalArchivesReleaseVersionsWebCrawler.groovy
+++ b/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/MetalArchivesReleaseVersionsWebCrawler.groovy
@@ -3,6 +3,7 @@ package rocks.metaldetector.butler.supplier.metalarchives
 import groovy.util.logging.Slf4j
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 @Slf4j
@@ -11,10 +12,14 @@ class MetalArchivesReleaseVersionsWebCrawler implements MetalArchivesReleaseImpo
 
   static final String REST_ENDPOINT = "https://www.metal-archives.com/release/ajax-versions/current/releaseId/parent/releaseId"
 
+  @Value('${concurrency.throttling-in-seconds}')
+  long throttlingInSeconds
+
   Document requestOtherReleases(String releaseId) {
     def url = REST_ENDPOINT.replaceAll("releaseId", releaseId)
     try {
-      throttle()
+      throttle(throttlingInSeconds)
+      log.info("Request 'other releases' page -> $url")
       return Jsoup.connect(url).get()
     }
     catch (Exception e) {

--- a/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/MetalArchivesReleaseVersionsWebCrawler.groovy
+++ b/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/MetalArchivesReleaseVersionsWebCrawler.groovy
@@ -7,13 +7,14 @@ import org.springframework.stereotype.Component
 
 @Slf4j
 @Component
-class MetalArchivesReleaseVersionsWebCrawler {
+class MetalArchivesReleaseVersionsWebCrawler implements MetalArchivesReleaseImportUtils {
 
   static final String REST_ENDPOINT = "https://www.metal-archives.com/release/ajax-versions/current/releaseId/parent/releaseId"
 
   Document requestOtherReleases(String releaseId) {
     def url = REST_ENDPOINT.replaceAll("releaseId", releaseId)
     try {
+      throttle()
       return Jsoup.connect(url).get()
     }
     catch (Exception e) {

--- a/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/cover/MetalArchivesCoverFetcher.groovy
+++ b/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/cover/MetalArchivesCoverFetcher.groovy
@@ -6,11 +6,14 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.jsoup.select.Elements
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import rocks.metaldetector.butler.supplier.infrastructure.ReleaseEntityDeleteRequestEvent
 import rocks.metaldetector.butler.supplier.infrastructure.cover.CoverFetcher
 import rocks.metaldetector.butler.supplier.metalarchives.MetalArchivesReleaseImportUtils
+
+import java.util.concurrent.atomic.AtomicInteger
 
 @Slf4j
 @Service
@@ -19,14 +22,17 @@ class MetalArchivesCoverFetcher implements CoverFetcher, MetalArchivesReleaseImp
   static final String RELEASE_PAGE_NOT_FOUND_ERROR_MESSAGE = "status code: 404"
   static final String ALBUM_COVER_HTML_ID = "cover"
   static final int MAX_ATTEMPTS = 5
-  int currentAttempt
+  AtomicInteger currentAttempt
 
   @Autowired
   ApplicationEventPublisher eventPublisher
 
+  @Value('${concurrency.throttling-in-seconds}')
+  long throttlingInSeconds
+
   @Override
   String fetchCoverUrl(String sourceUrl) {
-    currentAttempt = 0
+    currentAttempt = new AtomicInteger(0)
     Document releasePage = fetchReleasePage(sourceUrl)
     Elements coverDivs = releasePage?.select("a")
         ?.findAll { it.id() == ALBUM_COVER_HTML_ID }
@@ -36,9 +42,9 @@ class MetalArchivesCoverFetcher implements CoverFetcher, MetalArchivesReleaseImp
   }
 
   private Document fetchReleasePage(String sourceUrl) {
-    throttle()
+    throttle(throttlingInSeconds)
     try {
-      currentAttempt++
+      currentAttempt.incrementAndGet()
       return Jsoup.connect(sourceUrl).get()
     }
     catch (Exception e) {
@@ -52,14 +58,14 @@ class MetalArchivesCoverFetcher implements CoverFetcher, MetalArchivesReleaseImp
       eventPublisher.publishEvent(new ReleaseEntityDeleteRequestEvent(this, sourceUrl))
       return null
     }
-    else if (currentAttempt < MAX_ATTEMPTS) {
+    else if (currentAttempt.intValue() < MAX_ATTEMPTS) {
       log.info("The release page '${sourceUrl}' could not be fetched. Reason: $exception.message. " +
                "Will wait some time and try again ($currentAttempt/$MAX_ATTEMPTS).")
-      throttle()
+      throttle(throttlingInSeconds)
       return fetchReleasePage(sourceUrl)
     }
     else {
-      log.error("5 errors in a row during fetching the release page. I give up.", exception)
+      log.error("$MAX_ATTEMPTS errors in a row during fetching the release page. I give up.", exception)
       return null
     }
   }

--- a/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/importjob/ReissueHintEnhancer.groovy
+++ b/supplier/metal-archives/src/main/groovy/rocks/metaldetector/butler/supplier/metalarchives/importjob/ReissueHintEnhancer.groovy
@@ -1,0 +1,40 @@
+package rocks.metaldetector.butler.supplier.metalarchives.importjob
+
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import org.springframework.stereotype.Service
+import rocks.metaldetector.butler.persistence.domain.release.ReleaseEntity
+import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
+import rocks.metaldetector.butler.supplier.metalarchives.MetalArchivesReleaseVersionsWebCrawler
+
+@Service
+@Slf4j
+class ReissueHintEnhancer {
+
+  @Autowired
+  ThreadPoolTaskExecutor threadPoolTaskExecutor
+
+  @Autowired
+  ReleaseRepository releaseRepository
+
+  @Autowired
+  MetalArchivesReleaseVersionsWebCrawler webCrawler
+
+  void enhance(List<ReleaseEntity> newReleaseEntities) {
+    log.info("Enhance reissue hint for ${newReleaseEntities.size()} releases...")
+    def futures = newReleaseEntities.collect {
+      threadPoolTaskExecutor.submit(createReissueTask(it))
+    }
+
+    futures*.get()
+    releaseRepository.saveAll(newReleaseEntities)
+  }
+
+  private MetalArchivesReissueTask createReissueTask(ReleaseEntity releaseEntity) {
+    return new MetalArchivesReissueTask(
+        releaseEntity: releaseEntity,
+        webCrawler: webCrawler
+    )
+  }
+}

--- a/supplier/metal-archives/src/test/groovy/rocks/metaldetector/butler/supplier/metalarchives/importjob/MetalArchivesReleaseImporterTest.groovy
+++ b/supplier/metal-archives/src/test/groovy/rocks/metaldetector/butler/supplier/metalarchives/importjob/MetalArchivesReleaseImporterTest.groovy
@@ -3,22 +3,25 @@ package rocks.metaldetector.butler.supplier.metalarchives.importjob
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
 import rocks.metaldetector.butler.supplier.infrastructure.cover.CoverService
+import rocks.metaldetector.butler.supplier.infrastructure.importjob.ParallelCoverDownloader
 import rocks.metaldetector.butler.supplier.metalarchives.MetalArchivesRestClient
 import rocks.metaldetector.butler.supplier.metalarchives.converter.MetalArchivesReleaseEntityConverter
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import static rocks.metaldetector.butler.persistence.domain.release.ReleaseSource.METAL_ARCHIVES
-import static rocks.metaldetector.butler.supplier.metalarchives.DtoFactory.ReleaseEntityFactory
+import static rocks.metaldetector.butler.supplier.metalarchives.DtoFactory.ReleaseEntityFactory.*
 
 class MetalArchivesReleaseImporterTest extends Specification {
 
   MetalArchivesReleaseImporter underTest = new MetalArchivesReleaseImporter(
       restClient: Mock(MetalArchivesRestClient),
-      releaseEntityConverter: Mock(MetalArchivesReleaseEntityConverter),
       metalArchivesCoverService: Mock(CoverService),
+      releaseEntityConverter: Mock(MetalArchivesReleaseEntityConverter),
       releaseRepository: Mock(ReleaseRepository),
-      threadPoolTaskExecutor: Mock(ThreadPoolTaskExecutor)
+      threadPoolTaskExecutor: Mock(ThreadPoolTaskExecutor),
+      reissueHintEnhancer: Mock(ReissueHintEnhancer),
+      coverDownloader: Mock(ParallelCoverDownloader)
   )
 
   def "rest client is called once on import"() {
@@ -51,36 +54,19 @@ class MetalArchivesReleaseImporterTest extends Specification {
     ]
   }
 
-  def "a reissue task is created for every new release"() {
+  def "should call release hint enhancer"() {
     given:
-    def releaseEntities = [ReleaseEntityFactory.createReleaseEntity("A"), ReleaseEntityFactory.createReleaseEntity("B")]
     underTest.restClient.requestReleases() >> [new String[0]]
+    def releaseEntities = [createReleaseEntity("A"), createReleaseEntity("B")]
     underTest.releaseEntityConverter.convert(*_) >> releaseEntities
     underTest.releaseRepository.saveAll(*_) >> releaseEntities
+    underTest.coverDownloader.downloadAndSave(*_) >> releaseEntities
 
     when:
     underTest.importReleases()
 
     then:
-    2 * underTest.threadPoolTaskExecutor.submit({ args -> args instanceof MetalArchivesReissueTask })
-  }
-
-  def "new releases are saved after reissue task"() {
-    given:
-    def releaseEntities = [ReleaseEntityFactory.createReleaseEntity("A"), ReleaseEntityFactory.createReleaseEntity("B")]
-    def newReleaseEntity = [ReleaseEntityFactory.createReleaseEntity("A")]
-    underTest.restClient.requestReleases() >> [new String[0]]
-    underTest.releaseEntityConverter.convert(*_) >> releaseEntities
-    underTest.releaseRepository.saveAll(*_) >> newReleaseEntity
-
-    when:
-    underTest.importReleases()
-
-    then:
-    1 * underTest.threadPoolTaskExecutor.submit({ args -> args instanceof MetalArchivesReissueTask })
-
-    then:
-    underTest.releaseRepository.saveAll(newReleaseEntity)
+    1 * underTest.reissueHintEnhancer.enhance(*_)
   }
 
   def "should return METAL_ARCHIVES as release source"() {

--- a/supplier/metal-archives/src/test/groovy/rocks/metaldetector/butler/supplier/metalarchives/importjob/ReissueHintEnhancerTest.groovy
+++ b/supplier/metal-archives/src/test/groovy/rocks/metaldetector/butler/supplier/metalarchives/importjob/ReissueHintEnhancerTest.groovy
@@ -1,0 +1,55 @@
+package rocks.metaldetector.butler.supplier.metalarchives.importjob
+
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
+import rocks.metaldetector.butler.supplier.metalarchives.MetalArchivesReleaseVersionsWebCrawler
+import spock.lang.Specification
+
+import static rocks.metaldetector.butler.supplier.metalarchives.DtoFactory.ReleaseEntityFactory.createReleaseEntity
+
+class ReissueHintEnhancerTest extends Specification {
+
+  ReissueHintEnhancer underTest = new ReissueHintEnhancer(
+      releaseRepository: Mock(ReleaseRepository),
+      threadPoolTaskExecutor: Mock(ThreadPoolTaskExecutor),
+      webCrawler: Mock(MetalArchivesReleaseVersionsWebCrawler)
+  )
+
+  def "a reissue task is created for every new release"() {
+    given:
+    def release1 = createReleaseEntity("a")
+    def release2 = createReleaseEntity("b")
+    def releaseEntities = [release1, release2]
+
+    when:
+    underTest.enhance(releaseEntities)
+
+    then:
+    1 * underTest.threadPoolTaskExecutor.submit({ args ->
+      args instanceof MetalArchivesReissueTask
+          && args.releaseEntity == release1
+          && args.webCrawler == underTest.webCrawler
+    })
+
+    and:
+    1 * underTest.threadPoolTaskExecutor.submit({ args ->
+      args instanceof MetalArchivesReissueTask
+          && args.releaseEntity == release2
+          && args.webCrawler == underTest.webCrawler
+    })
+  }
+
+  def "should call release repository to save all new releases"() {
+    given:
+    def releaseEntities = [
+        createReleaseEntity("a"),
+        createReleaseEntity("b")
+    ]
+
+    when:
+    underTest.enhance(releaseEntities)
+
+    then:
+    1 * underTest.releaseRepository.saveAll(releaseEntities)
+  }
+}


### PR DESCRIPTION
I have modified the Metal Archives import a bit so that individual batches are already saved. Then we are a bit more robust in case of an error. Currently, the entire import progress is discarded as soon as an error occurs.