### PR TITLE
import jobs are scheduled and createJob endpoint returns job ids

### DIFF
--- a/app/src/main/groovy/rocks/metaldetector/butler/config/security/SecurityConfig.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/config/security/SecurityConfig.groovy
@@ -12,6 +12,7 @@ import static org.springframework.http.HttpMethod.GET
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.AntPattern.ACTUATOR_ENDPOINTS
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.COVER_JOB
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.FETCH_IMPORT_JOB
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.IMPORT_JOB
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASES
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.RELEASES_UNPAGINATED
@@ -39,7 +40,7 @@ class SecurityConfig {
               .requestMatchers(RELEASES).hasAuthority("SCOPE_releases-read")
               .requestMatchers(UPDATE_RELEASE).hasAuthority("SCOPE_releases-write")
               .requestMatchers(RELEASES_UNPAGINATED).hasAuthority("SCOPE_releases-read-all")
-              .requestMatchers(IMPORT_JOB, COVER_JOB).hasAuthority("SCOPE_import")
+              .requestMatchers(FETCH_IMPORT_JOB, IMPORT_JOB, COVER_JOB).hasAuthority("SCOPE_import")
               .requestMatchers(STATISTICS).hasAuthority("SCOPE_statistics")
               .anyRequest().denyAll()
         }

--- a/app/src/main/groovy/rocks/metaldetector/butler/service/importjob/ImportJobService.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/service/importjob/ImportJobService.groovy
@@ -7,6 +7,7 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import rocks.metaldetector.butler.config.web.ResourceNotFoundException
 import rocks.metaldetector.butler.persistence.domain.importjob.ImportJobEntity
 import rocks.metaldetector.butler.persistence.domain.importjob.ImportJobRepository
 import rocks.metaldetector.butler.persistence.domain.importjob.JobState
@@ -73,6 +74,7 @@ class ImportJobService {
   @Transactional(readOnly = true)
   ImportJobDto findImportJobById(String jobId) {
     ImportJobEntity importJob = importJobRepository.findByJobId(UUID.fromString(jobId))
+        .orElseThrow(() -> new ResourceNotFoundException("Job ${jobId} not present"))
     return importJobTransformer.transform(importJob)
   }
 

--- a/app/src/main/groovy/rocks/metaldetector/butler/service/importjob/ImportJobTask.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/service/importjob/ImportJobTask.groovy
@@ -19,16 +19,13 @@ class ImportJobTask implements Runnable {
   @Override
   void run() {
     importJobService.updateImportJob(importJob, RUNNING)
-    ImportResult importResult = null
     try {
-      importResult = releaseImporter.importReleases()
+      ImportResult importResult = releaseImporter.importReleases()
+      importJobService.updateImportJob(importJob, SUCCESSFUL, importResult)
     }
     catch (Exception e) {
       log.error("Error during import of releases from '${releaseImporter.getReleaseSource()?.displayName}'", e)
       importJobService.updateImportJob(importJob, ERROR)
-    }
-    if (importResult) {
-      importJobService.updateImportJob(importJob, SUCCESSFUL, importResult)
     }
   }
 }

--- a/app/src/main/groovy/rocks/metaldetector/butler/service/importjob/ImportJobTask.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/service/importjob/ImportJobTask.groovy
@@ -1,0 +1,34 @@
+package rocks.metaldetector.butler.service.importjob
+
+import groovy.util.logging.Slf4j
+import rocks.metaldetector.butler.persistence.domain.importjob.ImportJobEntity
+import rocks.metaldetector.butler.supplier.infrastructure.importjob.ImportResult
+import rocks.metaldetector.butler.supplier.infrastructure.importjob.ReleaseImporter
+
+import static rocks.metaldetector.butler.persistence.domain.importjob.JobState.ERROR
+import static rocks.metaldetector.butler.persistence.domain.importjob.JobState.RUNNING
+import static rocks.metaldetector.butler.persistence.domain.importjob.JobState.SUCCESSFUL
+
+@Slf4j
+class ImportJobTask implements Runnable {
+
+  ReleaseImporter releaseImporter
+  ImportJobService importJobService
+  ImportJobEntity importJob
+
+  @Override
+  void run() {
+    importJobService.updateImportJob(importJob, RUNNING)
+    ImportResult importResult = null
+    try {
+      importResult = releaseImporter.importReleases()
+    }
+    catch (Exception e) {
+      log.error("Error during import of releases from '${releaseImporter.getReleaseSource()?.displayName}'", e)
+      importJobService.updateImportJob(importJob, ERROR)
+    }
+    if (importResult) {
+      importJobService.updateImportJob(importJob, SUCCESSFUL, importResult)
+    }
+  }
+}

--- a/app/src/main/groovy/rocks/metaldetector/butler/service/importjob/ImportJobTransformer.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/service/importjob/ImportJobTransformer.groovy
@@ -10,7 +10,7 @@ class ImportJobTransformer {
   ImportJobDto transform(ImportJobEntity importJobEntity) {
     if (importJobEntity) {
       return new ImportJobDto(
-              jobId: importJobEntity.jobId,
+              jobId: importJobEntity.jobId.toString(),
               totalCountRequested: importJobEntity.totalCountRequested,
               totalCountImported: importJobEntity.totalCountImported,
               startTime: importJobEntity.startTime,

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/api/ImportJobCreatedResponse.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/api/ImportJobCreatedResponse.groovy
@@ -1,0 +1,9 @@
+package rocks.metaldetector.butler.web.api
+
+import groovy.transform.Canonical
+
+@Canonical
+class ImportJobCreatedResponse {
+
+  List<String> importJobIds
+}

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/dto/ImportJobDto.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/dto/ImportJobDto.groovy
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
 @Canonical
 class ImportJobDto {
 
-  UUID jobId
+  String jobId
   Integer totalCountRequested
   Integer totalCountImported
   LocalDateTime startTime

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestController.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestController.groovy
@@ -3,14 +3,17 @@ package rocks.metaldetector.butler.web.rest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 import rocks.metaldetector.butler.service.importjob.ImportJobService
+import rocks.metaldetector.butler.web.api.ImportJobCreatedResponse
 import rocks.metaldetector.butler.web.api.ImportJobResponse
 import rocks.metaldetector.butler.web.dto.ImportJobDto
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.COVER_JOB
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.FETCH_IMPORT_JOB
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.IMPORT_JOB
 
 @RestController
@@ -20,16 +23,22 @@ class ImportJobRestController {
   ImportJobService importJobService
 
   @GetMapping(path = IMPORT_JOB, produces = APPLICATION_JSON_VALUE)
-  ResponseEntity<ImportJobResponse> getAllImportJobResults() {
-    List<ImportJobDto> importJobs = importJobService.findAllImportJobResults()
+  ResponseEntity<ImportJobResponse> getAllImportJobs() {
+    List<ImportJobDto> importJobs = importJobService.findAllImportJobs()
     ImportJobResponse response = new ImportJobResponse(importJobs:  importJobs)
     return ResponseEntity.ok(response)
   }
 
+  @GetMapping(path = FETCH_IMPORT_JOB, produces = APPLICATION_JSON_VALUE)
+  ResponseEntity<ImportJobDto> getImportJob(@PathVariable("jobId") String jobId) {
+    return ResponseEntity.ok(importJobService.findImportJobById(jobId))
+  }
+
   @PostMapping(path = IMPORT_JOB, produces = APPLICATION_JSON_VALUE)
-  ResponseEntity<Void> createImportJob() {
-    importJobService.importFromExternalSources()
-    return ResponseEntity.ok().build()
+  ResponseEntity<ImportJobCreatedResponse> createImportJob() {
+    List<String> jobIds = importJobService.createImportJobs()
+    ImportJobCreatedResponse response = new ImportJobCreatedResponse(importJobIds: jobIds)
+    return ResponseEntity.ok(response)
   }
 
   @PostMapping(path = COVER_JOB, produces = APPLICATION_JSON_VALUE)

--- a/app/src/main/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestController.groovy
+++ b/app/src/main/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestController.groovy
@@ -25,7 +25,7 @@ class ImportJobRestController {
   @GetMapping(path = IMPORT_JOB, produces = APPLICATION_JSON_VALUE)
   ResponseEntity<ImportJobResponse> getAllImportJobs() {
     List<ImportJobDto> importJobs = importJobService.findAllImportJobs()
-    ImportJobResponse response = new ImportJobResponse(importJobs:  importJobs)
+    ImportJobResponse response = new ImportJobResponse(importJobs: importJobs)
     return ResponseEntity.ok(response)
   }
 

--- a/app/src/main/resources/db/migration/v4_0__job_entity_update.sql
+++ b/app/src/main/resources/db/migration/v4_0__job_entity_update.sql
@@ -1,0 +1,4 @@
+-- Creation Date: 2023-10-12
+-- Description: start_time can be null in job entity
+
+alter table import_jobs alter column start_time drop not null;

--- a/app/src/test/groovy/rocks/metaldetector/butler/service/importjob/ImportJobServiceTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/service/importjob/ImportJobServiceTest.groovy
@@ -1,12 +1,16 @@
 package rocks.metaldetector.butler.service.importjob
 
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import rocks.metaldetector.butler.persistence.domain.importjob.ImportJobEntity
 import rocks.metaldetector.butler.persistence.domain.importjob.ImportJobRepository
+import rocks.metaldetector.butler.persistence.domain.importjob.JobState
 import rocks.metaldetector.butler.supplier.infrastructure.importjob.ImportResult
 import rocks.metaldetector.butler.supplier.infrastructure.importjob.ReleaseImporter
+import rocks.metaldetector.butler.web.dto.ImportJobDto
 import spock.lang.Specification
+import spock.lang.Unroll
 
-import static rocks.metaldetector.butler.persistence.domain.importjob.JobState.ERROR
+import static rocks.metaldetector.butler.persistence.domain.importjob.JobState.INITIALIZED
 import static rocks.metaldetector.butler.persistence.domain.importjob.JobState.RUNNING
 import static rocks.metaldetector.butler.persistence.domain.importjob.JobState.SUCCESSFUL
 import static rocks.metaldetector.butler.persistence.domain.release.ReleaseSource.METAL_ARCHIVES
@@ -17,18 +21,19 @@ class ImportJobServiceTest extends Specification {
 
   ImportJobService underTest = new ImportJobService(
       importJobRepository: Mock(ImportJobRepository),
-      importJobTransformer: Mock(ImportJobTransformer)
+      importJobTransformer: Mock(ImportJobTransformer),
+      releaseImportTaskExecutor: Mock(ThreadPoolTaskExecutor)
   )
 
-  def "findAllImportJobResults: should call import job repository"() {
+  def "findAllImportJobs: should call import job repository"() {
     when:
-    underTest.findAllImportJobResults()
+    underTest.findAllImportJobs()
 
     then:
     1 * underTest.importJobRepository.findAll()
   }
 
-  def "findAllImportJobResults: should transform each job entity with job transformer"() {
+  def "findAllImportJobs: should transform each job entity with job transformer"() {
     given:
     def jobEntities = [
         ImportJobEntityFactory.createImportJobEntity(),
@@ -37,7 +42,7 @@ class ImportJobServiceTest extends Specification {
     underTest.importJobRepository.findAll() >> jobEntities
 
     when:
-    underTest.findAllImportJobResults()
+    underTest.findAllImportJobs()
 
     then:
     1 * underTest.importJobTransformer.transform(jobEntities[0])
@@ -46,7 +51,7 @@ class ImportJobServiceTest extends Specification {
     1 * underTest.importJobTransformer.transform(jobEntities[1])
   }
 
-  def "findAllImportJobResults: should return list of transformed import jobs"() {
+  def "findAllImportJobs: should return list of transformed import jobs"() {
     given:
     def jobEntities = [
         ImportJobEntityFactory.createImportJobEntity(),
@@ -55,69 +60,78 @@ class ImportJobServiceTest extends Specification {
     underTest.importJobRepository.findAll() >> jobEntities
 
     when:
-    def results = underTest.findAllImportJobResults()
+    def results = underTest.findAllImportJobs()
 
     then:
     results.size() == jobEntities.size()
   }
 
-  def "importFromExternalSources: should create a new import job, invoking 'importReleases()' and update the import job in this order"() {
+  def "findImportJobById: repository is called with given id"() {
+    given:
+    def jobId = UUID.randomUUID()
+
+    when:
+    underTest.findImportJobById(jobId.toString())
+
+    then:
+    1 * underTest.importJobRepository.findByJobId(jobId)
+  }
+
+  def "findImportJobById: transformer is called with job"() {
+    given:
+    def jobId = UUID.randomUUID()
+    def job = new ImportJobEntity(jobId:  jobId)
+    underTest.importJobRepository.findByJobId(*_) >> job
+
+    when:
+    underTest.findImportJobById(jobId.toString())
+
+    then:
+    1 * underTest.importJobTransformer.transform(job)
+  }
+
+  def "findImportJobById: dto is returned"() {
+    given:
+    def jobId = UUID.randomUUID().toString()
+    def jobDto = new ImportJobDto(jobId: jobId)
+    underTest.importJobTransformer.transform(*_) >> jobDto
+
+    when:
+    def result = underTest.findImportJobById(jobId)
+
+    then:
+    result == jobDto
+  }
+
+  def "createImportJobs: should create a new import job, schedule a task and return the jobId in this order"() {
     given:
     def releaseImporterMock = Mock(ReleaseImporter)
     underTest.releaseImporters = [releaseImporterMock]
     releaseImporterMock.releaseSource >> METAL_ARCHIVES
-    ImportResult importResult = new ImportResult(totalCountRequested: 10, totalCountImported: 5)
     ImportJobEntity metalArchivesImportJob = new ImportJobEntity(jobId: UUID.randomUUID())
 
     when:
-    underTest.importFromExternalSources()
+    def result = underTest.createImportJobs()
 
     then:
     1 * underTest.importJobRepository.save({
       it.jobId != null
-      it.startTime != null
+      it.state == INITIALIZED
       it.source == METAL_ARCHIVES
     }) >> metalArchivesImportJob
 
     then:
-    1 * releaseImporterMock.importReleases() >> importResult
-
-    then:
-    1 * underTest.importJobRepository.save({ args ->
-      args.jobId == metalArchivesImportJob.jobId
-      args.totalCountRequested == importResult.totalCountRequested
-      args.totalCountImported == importResult.totalCountImported
-      args.state == SUCCESSFUL
-      args.endTime
-    })
-  }
-
-  def "importFromExternalSources: should handle any exception and update the import job with state ERROR"() {
-    given:
-    def releaseImporterMock = Mock(ReleaseImporter)
-    underTest.releaseImporters = [releaseImporterMock]
-    releaseImporterMock.releaseSource >> METAL_ARCHIVES
-    ImportJobEntity metalArchivesImportJob = new ImportJobEntity(jobId: UUID.randomUUID())
-    underTest.importJobRepository.save(*_) >> metalArchivesImportJob
-    releaseImporterMock.importReleases() >> { throw new RuntimeException("boom") }
-
-    when:
-    underTest.importFromExternalSources()
-
-    then:
-    1 * underTest.importJobRepository.save({ args ->
-      args.jobId == metalArchivesImportJob.jobId
-      args.totalCountRequested == null
-      args.totalCountImported == null
-      args.state == ERROR
-      args.endTime
+    1 * underTest.releaseImportTaskExecutor.submit({
+      it.releaseImporter == releaseImporterMock
+      it.importJobService == underTest
+      it.importJob == metalArchivesImportJob
     })
 
     and:
-    noExceptionThrown()
+    result == [metalArchivesImportJob.jobId.toString()]
   }
 
-  def "importFromExternalSources: should process the release importers according to the specified order"() {
+  def "createImportJobs: should process every release importer"() {
     given:
     def releaseImporterMock1 = Mock(ReleaseImporter)
     def releaseImporterMock2 = Mock(ReleaseImporter)
@@ -127,26 +141,43 @@ class ImportJobServiceTest extends Specification {
     underTest.importJobRepository.save(*_) >> new ImportJobEntity()
 
     when:
-    underTest.importFromExternalSources()
+    underTest.createImportJobs()
 
     then:
-    1 * releaseImporterMock1.importReleases() >> new ImportResult()
+    1 * underTest.releaseImportTaskExecutor.submit({ it.releaseImporter == releaseImporterMock1 })
 
-    then:
-    1 * releaseImporterMock2.importReleases() >> new ImportResult()
+    and:
+    1 * underTest.releaseImportTaskExecutor.submit({ it.releaseImporter == releaseImporterMock2 })
   }
 
-  def "updateImportJob: should update the corresponding import job"() {
+  @Unroll
+  "updateImportJob: should update the corresponding import job's state to '#jobState'"() {
     given:
     def importJobEntity = new ImportJobEntity(jobId: UUID.randomUUID())
-    def jobState = SUCCESSFUL
+
+    when:
+    underTest.updateImportJob(importJobEntity, jobState)
+
+    then:
+    1 * underTest.importJobRepository.save({ args ->
+      args.jobId == importJobEntity.jobId
+      args.state == jobState
+    })
+
+    where:
+    jobState << JobState.values()
+  }
+
+  def "updateImportJob: if state is 'SUCCESSFUL', import result info is set"() {
+    given:
+    def importJobEntity = new ImportJobEntity(jobId: UUID.randomUUID())
     def importResult = new ImportResult(
         totalCountRequested: 10,
         totalCountImported: 5
     )
 
     when:
-    underTest.updateImportJob(importJobEntity, importResult, jobState)
+    underTest.updateImportJob(importJobEntity, SUCCESSFUL, importResult)
 
     then:
     1 * underTest.importJobRepository.save({ args ->
@@ -154,6 +185,20 @@ class ImportJobServiceTest extends Specification {
       args.totalCountRequested == importResult.totalCountRequested
       args.totalCountImported == importResult.totalCountImported
       args.endTime
+    })
+  }
+
+  def "updateImportJob: if state is 'RUNNING', startTime is set"() {
+    given:
+    def importJobEntity = new ImportJobEntity(jobId: UUID.randomUUID())
+
+    when:
+    underTest.updateImportJob(importJobEntity, RUNNING)
+
+    then:
+    1 * underTest.importJobRepository.save({ args ->
+      args.jobId == importJobEntity.jobId
+      args.startTime
     })
   }
 
@@ -167,8 +212,7 @@ class ImportJobServiceTest extends Specification {
     then:
     1 * underTest.importJobRepository.save({ args ->
       args.jobId
-      args.startTime
-      args.state == RUNNING
+      args.state == INITIALIZED
       args.source == givenReleaseSource
     })
   }

--- a/app/src/test/groovy/rocks/metaldetector/butler/service/importjob/ImportJobTaskTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/service/importjob/ImportJobTaskTest.groovy
@@ -1,0 +1,56 @@
+package rocks.metaldetector.butler.service.importjob
+
+import rocks.metaldetector.butler.persistence.domain.importjob.ImportJobEntity
+import rocks.metaldetector.butler.supplier.infrastructure.importjob.ImportResult
+import rocks.metaldetector.butler.supplier.infrastructure.importjob.ReleaseImporter
+import spock.lang.Specification
+
+import static rocks.metaldetector.butler.persistence.domain.importjob.JobState.ERROR
+import static rocks.metaldetector.butler.persistence.domain.importjob.JobState.RUNNING
+import static rocks.metaldetector.butler.persistence.domain.importjob.JobState.SUCCESSFUL
+
+class ImportJobTaskTest extends Specification {
+
+  ImportJobTask underTest = new ImportJobTask(releaseImporter: Mock(ReleaseImporter),
+                                              importJobService: Mock(ImportJobService),
+                                              importJob: Mock(ImportJobEntity))
+
+  def "importJob's state is updated to RUNNING"() {
+    when:
+    underTest.run()
+
+    then:
+    1 * underTest.importJobService.updateImportJob(underTest.importJob, RUNNING)
+  }
+
+  def "releaseImporter is triggered"() {
+    when:
+    underTest.run()
+
+    then:
+    1 * underTest.releaseImporter.importReleases()
+  }
+
+  def "importJob's state is updated to SUCCESSFUL"() {
+    given:
+    def jobResult = new ImportResult(totalCountImported: 666)
+    underTest.releaseImporter.importReleases() >> jobResult
+
+    when:
+    underTest.run()
+
+    then:
+    1 * underTest.importJobService.updateImportJob(underTest.importJob, SUCCESSFUL, jobResult)
+  }
+
+  def "importJob's state is updated to ERROR"() {
+    given:
+    underTest.releaseImporter.importReleases() >> { throw new RuntimeException("BOOM") }
+
+    when:
+    underTest.run()
+
+    then:
+    1 * underTest.importJobService.updateImportJob(underTest.importJob, ERROR)
+  }
+}

--- a/app/src/test/groovy/rocks/metaldetector/butler/service/importjob/ImportJobTransformerTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/service/importjob/ImportJobTransformerTest.groovy
@@ -26,7 +26,7 @@ class ImportJobTransformerTest extends Specification {
     def result = underTest.transform(importJobEntity)
 
     then:
-    result.jobId == jobId
+    result.jobId == jobId.toString()
   }
 
   def "should transform 'totalCountRequested'"() {

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestControllerIntegrationTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestControllerIntegrationTest.groovy
@@ -17,6 +17,7 @@ import static org.springframework.http.HttpStatus.OK
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.COVER_JOB
+import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.FETCH_IMPORT_JOB
 import static rocks.metaldetector.butler.supplier.infrastructure.Endpoints.IMPORT_JOB
 
 @SpringBootTest
@@ -52,6 +53,32 @@ class ImportJobRestControllerIntegrationTest extends Specification implements Wi
     given:
     jwtDecoder.decode(*_) >> OTHER_SCOPE_JWT
     def request = get(IMPORT_JOB).header("Authorization", "Bearer $OTHER_SCOPE_JWT.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == FORBIDDEN.value()
+  }
+
+  def "Scope 'import' can GET on single import endpoint"() {
+    given:
+    jwtDecoder.decode(*_) >> IMPORT_JWT
+    def request = get(FETCH_IMPORT_JOB.replace("{jobId}", "123"))
+        .header("Authorization", "Bearer $IMPORT_JWT.tokenValue")
+
+    when:
+    def result = mockMvc.perform(request).andReturn()
+
+    then:
+    result.response.status == OK.value()
+  }
+
+  def "Other scopes cannot GET on single import endpoint"() {
+    given:
+    jwtDecoder.decode(*_) >> OTHER_SCOPE_JWT
+    def request = get(FETCH_IMPORT_JOB.replace("{jobId}", "123"))
+        .header("Authorization", "Bearer $OTHER_SCOPE_JWT.tokenValue")
 
     when:
     def result = mockMvc.perform(request).andReturn()

--- a/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestControllerTest.groovy
+++ b/app/src/test/groovy/rocks/metaldetector/butler/web/rest/ImportJobRestControllerTest.groovy
@@ -11,21 +11,21 @@ class ImportJobRestControllerTest extends Specification {
 
   ImportJobRestController underTest = new ImportJobRestController(importJobService: Mock(ImportJobService))
 
-  def "Getting all import job results should call ImportJobService"() {
+  def "Getting all import jobs should call ImportJobService"() {
     when:
-    underTest.getAllImportJobResults()
+    underTest.getAllImportJobs()
 
     then:
-    1 * underTest.importJobService.findAllImportJobResults()
+    1 * underTest.importJobService.findAllImportJobs()
   }
 
-  def "Getting all import job results should return wrapped result from ImportJobServicee"() {
+  def "Getting all import jobs should return wrapped result from ImportJobService"() {
     given:
     def importJobDto = new ImportJobDto(jobId: UUID.randomUUID())
-    underTest.importJobService.findAllImportJobResults() >> [importJobDto]
+    underTest.importJobService.findAllImportJobs() >> [importJobDto]
 
     when:
-    def result = underTest.getAllImportJobResults()
+    def result = underTest.getAllImportJobs()
 
     then:
     ImportJobResponse importJobResponse = result.body
@@ -36,12 +36,20 @@ class ImportJobRestControllerTest extends Specification {
     result.statusCode == OK
   }
 
+  def "Getting all import jobs should return OK"() {
+    when:
+    def result = underTest.getAllImportJobs()
+
+    then:
+    result.statusCode == OK
+  }
+
   def "Creating import job should call ImportJobService"() {
     when:
     underTest.createImportJob()
 
     then:
-    1 * underTest.importJobService.importFromExternalSources()
+    1 * underTest.importJobService.createImportJobs()
   }
 
   def "Creating import job should return OK"() {
@@ -50,6 +58,18 @@ class ImportJobRestControllerTest extends Specification {
 
     then:
     result.statusCode == OK
+  }
+
+  def "Creating import job should return jobIds"() {
+    given:
+    def expectedJobIds = ["1", "2", "3"]
+    underTest.importJobService.createImportJobs() >> expectedJobIds
+
+    when:
+    def result = underTest.createImportJob()
+
+    then:
+    result.body.importJobIds == expectedJobIds
   }
 
   def "Retrying cover download should call ImportJobService"() {
@@ -61,8 +81,43 @@ class ImportJobRestControllerTest extends Specification {
   }
 
   def "Retrying cover download should return OK"() {
-   when:
+    when:
     def result = underTest.retryCoverDownload()
+
+    then:
+    result.statusCode == OK
+  }
+
+  def "Fetching an import job should call ImportJobService"() {
+    given:
+    def jobId = "someId"
+
+    when:
+    underTest.getImportJob(jobId)
+
+    then:
+    1 * underTest.importJobService.findImportJobById(jobId)
+  }
+
+  def "Fetching import job should return result from ImportJobService"() {
+    given:
+    def importJobDto = new ImportJobDto(jobId: UUID.randomUUID())
+    underTest.importJobService.findImportJobById(*_) >> importJobDto
+
+    when:
+    def result = underTest.getImportJob("jobId")
+
+    then:
+    ImportJobDto importJob = result.body
+    importJob == importJobDto
+
+    and:
+    result.statusCode == OK
+  }
+
+  def "Fetching import job should return result OK"() {
+    when:
+    def result = underTest.getImportJob("jobId")
 
     then:
     result.statusCode == OK

--- a/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/importjob/ImportJobEntity.groovy
+++ b/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/importjob/ImportJobEntity.groovy
@@ -25,7 +25,7 @@ class ImportJobEntity extends BaseEntity {
   @Column(name = "total_count_imported", nullable = true)
   Integer totalCountImported
 
-  @Column(name = "start_time", nullable = false, columnDefinition = "timestamp")
+  @Column(name = "start_time", nullable = true, columnDefinition = "timestamp")
   LocalDateTime startTime
 
   @Column(name = "end_time", nullable = true, columnDefinition = "timestamp")

--- a/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/importjob/ImportJobRepository.groovy
+++ b/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/importjob/ImportJobRepository.groovy
@@ -21,5 +21,5 @@ interface ImportJobRepository extends JpaRepository<ImportJobEntity, Long> {
   @Query("select i.startTime from import_jobs i where i.source = :source and i.state = :state order by i.startTime desc limit 1")
   LocalDateTime findLastStartTimeByState(@Param("source") ReleaseSource source, @Param("state") JobState state)
 
-  ImportJobEntity findByJobId(UUID jobId)
+  Optional<ImportJobEntity> findByJobId(UUID jobId)
 }

--- a/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/importjob/ImportJobRepository.groovy
+++ b/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/importjob/ImportJobRepository.groovy
@@ -20,4 +20,6 @@ interface ImportJobRepository extends JpaRepository<ImportJobEntity, Long> {
 
   @Query("select i.startTime from import_jobs i where i.source = :source and i.state = :state order by i.startTime desc limit 1")
   LocalDateTime findLastStartTimeByState(@Param("source") ReleaseSource source, @Param("state") JobState state)
+
+  ImportJobEntity findByJobId(UUID jobId)
 }

--- a/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/importjob/JobState.groovy
+++ b/persistence/src/main/groovy/rocks/metaldetector/butler/persistence/domain/importjob/JobState.groovy
@@ -2,6 +2,7 @@ package rocks.metaldetector.butler.persistence.domain.importjob
 
 enum JobState {
 
+  INITIALIZED("Initialized"),
   RUNNING("Running"),
   SUCCESSFUL("Successful"),
   ERROR("Error")

--- a/persistence/src/test/groovy/rocks/metaldetector/butler/persistence/domain/importjob/ImportJobRepositoryIntegrationTest.groovy
+++ b/persistence/src/test/groovy/rocks/metaldetector/butler/persistence/domain/importjob/ImportJobRepositoryIntegrationTest.groovy
@@ -107,6 +107,9 @@ class ImportJobRepositoryIntegrationTest extends Specification implements WithIn
     def result = underTest.findByJobId(IMPORT_3.jobId)
 
     then:
-    result == IMPORT_3
+    result.isPresent()
+
+    and:
+    result.get() == IMPORT_3
   }
 }

--- a/persistence/src/test/groovy/rocks/metaldetector/butler/persistence/domain/importjob/ImportJobRepositoryIntegrationTest.groovy
+++ b/persistence/src/test/groovy/rocks/metaldetector/butler/persistence/domain/importjob/ImportJobRepositoryIntegrationTest.groovy
@@ -22,17 +22,17 @@ import static rocks.metaldetector.butler.persistence.domain.release.ReleaseSourc
 @ContextConfiguration(classes = [PersistenceConfig])
 class ImportJobRepositoryIntegrationTest extends Specification implements WithIntegrationTestConfig {
 
+  static ImportJobEntity IMPORT_1 = createImportJobEntity(METAL_ARCHIVES, SUCCESSFUL, LocalDateTime.of(2020, 1, 1, 1, 1), LocalDateTime.of(2020, 1, 1, 1, 3))
+  static ImportJobEntity IMPORT_2 = createImportJobEntity(METAL_ARCHIVES, SUCCESSFUL, LocalDateTime.of(2020, 1, 2, 1, 1), LocalDateTime.of(2020, 1, 2, 1, 3))
+  static ImportJobEntity IMPORT_3 = createImportJobEntity(METAL_ARCHIVES, ERROR, LocalDateTime.of(2020, 1, 3, 1, 1), LocalDateTime.of(2020, 1, 3, 1, 3))
+  static ImportJobEntity IMPORT_4 = createImportJobEntity(TIME_FOR_METAL, SUCCESSFUL, LocalDateTime.of(2020, 1, 1, 2, 1), LocalDateTime.of(2020, 1, 1, 2, 3))
+  static ImportJobEntity IMPORT_5 = createImportJobEntity(TIME_FOR_METAL, RUNNING, LocalDateTime.of(2020, 1, 2, 2, 1), LocalDateTime.of(2020, 1, 2, 2, 3))
+
   @Autowired
   ImportJobRepository underTest
 
-  static ImportJobEntity import1 = createImportJobEntity(METAL_ARCHIVES, SUCCESSFUL, LocalDateTime.of(2020, 1, 1, 1, 1), LocalDateTime.of(2020, 1, 1, 1, 3))
-  static ImportJobEntity import2 = createImportJobEntity(METAL_ARCHIVES, SUCCESSFUL, LocalDateTime.of(2020, 1, 2, 1, 1), LocalDateTime.of(2020, 1, 2, 1, 3))
-  static ImportJobEntity import3 = createImportJobEntity(METAL_ARCHIVES, ERROR, LocalDateTime.of(2020, 1, 3, 1, 1), LocalDateTime.of(2020, 1, 3, 1, 3))
-  static ImportJobEntity import4 = createImportJobEntity(TIME_FOR_METAL, SUCCESSFUL, LocalDateTime.of(2020, 1, 1, 2, 1), LocalDateTime.of(2020, 1, 1, 2, 3))
-  static ImportJobEntity import5 = createImportJobEntity(TIME_FOR_METAL, RUNNING, LocalDateTime.of(2020, 1, 2, 2, 1), LocalDateTime.of(2020, 1, 2, 2, 3))
-
   void setup() {
-    def imports = [import1, import2, import3, import4, import5]
+    def imports = [IMPORT_1, IMPORT_2, IMPORT_3, IMPORT_4, IMPORT_5]
     underTest.saveAll(imports)
   }
 
@@ -100,5 +100,13 @@ class ImportJobRepositoryIntegrationTest extends Specification implements WithIn
     TIME_FOR_METAL | SUCCESSFUL | LocalDateTime.of(2020, 1, 1, 2, 1)
     TIME_FOR_METAL | ERROR      | null
     TIME_FOR_METAL | RUNNING    | LocalDateTime.of(2020, 1, 2, 2, 1)
+  }
+
+  def "findByJobId: should return correct job"() {
+    when:
+    def result = underTest.findByJobId(IMPORT_3.jobId)
+
+    then:
+    result == IMPORT_3
   }
 }

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/Endpoints.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/Endpoints.groovy
@@ -8,6 +8,7 @@ class Endpoints {
   public static final String COVER_JOB            = "/rest/v1/releases/cover-reload"
   public static final String RELEASE_IMAGES       = "/rest/v1/releases/images"
   public static final String IMPORT_JOB           = "/rest/v1/releases/import"
+  public static final String FETCH_IMPORT_JOB     = "/rest/v1/releases/import/{jobId}"
   public static final String STATISTICS           = "/rest/v1/releases/statistics"
 
   static class AntPattern {

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/config/InfrastructureConfig.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/config/InfrastructureConfig.groovy
@@ -6,10 +6,13 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import rocks.metaldetector.butler.persistence.domain.release.ReleaseSource
 
 import java.time.Duration
 
+import static java.time.temporal.ChronoUnit.MINUTES
 import static java.time.temporal.ChronoUnit.SECONDS
+import static rocks.metaldetector.butler.persistence.domain.release.ReleaseSource.TEST
 
 @Configuration
 class InfrastructureConfig {
@@ -31,5 +34,12 @@ class InfrastructureConfig {
     return new ThreadPoolTaskExecutor(corePoolSize: releaseImportPoolSize,
                                       waitForTasksToCompleteOnShutdown: awaitTermination,
                                       awaitTerminationSeconds: awaitTerminationPeriod.get(SECONDS))
+  }
+
+  @Bean
+  ThreadPoolTaskExecutor releaseImportTaskExecutor() {
+    return new ThreadPoolTaskExecutor(corePoolSize: [ReleaseSource.values() - TEST].size(),
+                                      waitForTasksToCompleteOnShutdown: true,
+                                      awaitTerminationSeconds: Duration.of(10, MINUTES).getSeconds())
   }
 }

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/AbstractReleaseImporter.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/AbstractReleaseImporter.groovy
@@ -1,5 +1,6 @@
 package rocks.metaldetector.butler.supplier.infrastructure.importjob
 
+import groovy.transform.Synchronized
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
@@ -44,6 +45,7 @@ abstract class AbstractReleaseImporter implements ReleaseImporter {
     releaseRepository.saveAll(releaseEntitiesToUpdate)
   }
 
+  @Synchronized
   List<ReleaseEntity> saveNewReleasesWithCover(List<ReleaseEntity> releaseEntities) {
     def newReleases = preFilter(releaseEntities)
     log.info("Out of ${releaseEntities.size()} requested releases, ${newReleases.size()} new releases are imported")


### PR DESCRIPTION
Currently the import is kind of 'fake asynchron'. The controller returns fast but the jobs run chronologically and we have no means to check on them. So what I did is remove the @Async annotation on the service and instead schedule the imports in a new threadPoolExecutor. The method returns the job's Ids and with a new endpoint these IDs can be requested to check on the state of the jobs.
Parallel imports brings the problem that we have to synchronize writing and reading on the release repository. In this PR I'm going the easy way and simply synchronize the whole saving of the releases. That's easy and safe but we also loose a lot of the advantage of parallelizing the imports. I'll take a look at that later on, I think with some read and write locks we can improve this quite a bit, but maybe some more work has to be done as the logic of downloading and saving stuff is spread quite a lot.
I did a quick test, the API changes should be completely backwards compatible. But I'll create a PR in the detector with my other changes soon.