### PR TITLE
Sync repository access

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,7 @@ val dependencyVersions = listOf(
     "org.opentest4j:opentest4j:1.3.0"
 )
 
-val dependencyGroupVersions = mapOf(
-    libs.groovy.get().group to libs.groovy.get().version,
-    libs.jupiterApi.get().group to libs.jupiterApi.get().version
-)
+val dependencyGroupVersions = mapOf<String, String>()
 
 plugins {
   alias(libs.plugins.springBoot) apply false

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/config/SynchronicityConfig.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/config/SynchronicityConfig.groovy
@@ -1,0 +1,15 @@
+package rocks.metaldetector.butler.supplier.infrastructure.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+import java.util.concurrent.locks.ReentrantReadWriteLock
+
+@Configuration
+class SynchronicityConfig {
+
+  @Bean
+  ReentrantReadWriteLock reentrantReadWriteLock() {
+    new ReentrantReadWriteLock()
+  }
+}

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/AbstractReleaseImporter.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/AbstractReleaseImporter.groovy
@@ -67,9 +67,10 @@ abstract class AbstractReleaseImporter implements ReleaseImporter {
   }
 
   private List<ReleaseEntity> preFilter(List<ReleaseEntity> releaseEntities) {
+    def uniqueReleases = releaseEntities.unique(false, RELEASE_ENTITY_COMPARATOR)
     reentrantReadWriteLock.readLock().lock()
     try {
-      return releaseEntities.unique(false, RELEASE_ENTITY_COMPARATOR)
+      return uniqueReleases
           .findAll { releaseEntity ->
             !releaseRepository.existsByArtistIgnoreCaseAndAlbumTitleIgnoreCaseAndReleaseDate(releaseEntity.artist, releaseEntity.albumTitle, releaseEntity.releaseDate)
           }

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/AbstractReleaseImporter.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/AbstractReleaseImporter.groovy
@@ -1,6 +1,5 @@
 package rocks.metaldetector.butler.supplier.infrastructure.importjob
 
-import groovy.transform.Synchronized
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
@@ -9,6 +8,7 @@ import rocks.metaldetector.butler.persistence.domain.release.ReleaseEntity
 import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
 
 import java.util.concurrent.Future
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 @Slf4j
 abstract class AbstractReleaseImporter implements ReleaseImporter {
@@ -26,6 +26,9 @@ abstract class AbstractReleaseImporter implements ReleaseImporter {
 
   @Autowired
   ThreadPoolTaskExecutor threadPoolTaskExecutor
+
+  @Autowired
+  ReentrantReadWriteLock reentrantReadWriteLock
 
   @Override
   @Transactional
@@ -45,34 +48,52 @@ abstract class AbstractReleaseImporter implements ReleaseImporter {
     releaseRepository.saveAll(releaseEntitiesToUpdate)
   }
 
-  @Synchronized
+  @Transactional
   List<ReleaseEntity> saveNewReleasesWithCover(List<ReleaseEntity> releaseEntities) {
     def newReleases = preFilter(releaseEntities)
-    log.info("Out of ${releaseEntities.size()} requested releases, ${newReleases.size()} new releases are imported")
-
     int batch = 0
     List<ReleaseEntity> savedReleaseEntities = []
     List<List<ReleaseEntity>> releaseBatches = newReleases.collate(BATCH_SIZE)
     for (List<ReleaseEntity> releaseBatch : releaseBatches) {
       log.info("Transfer covers for batch ${++batch}/${releaseBatches.size()}")
-      savedReleaseEntities += coverDownloader.downloadAndSave(releaseBatch, releaseEntity -> createCoverDownloadTask(releaseEntity))
+      coverDownloader.download(releaseBatch, releaseEntity -> createCoverDownloadTask(releaseEntity))
+      savedReleaseEntities += save(releaseBatch)
       log.info("Releases for batch ${batch}/${releaseBatches.size()} successfully saved.")
     }
+
+    log.info("Out of ${releaseEntities.size()} requested releases, ${savedReleaseEntities.size()} new releases are imported")
 
     return savedReleaseEntities
   }
 
   private List<ReleaseEntity> preFilter(List<ReleaseEntity> releaseEntities) {
-    return releaseEntities.unique(false, RELEASE_ENTITY_COMPARATOR)
-        .findAll { releaseEntity ->
-          !releaseRepository.existsByArtistIgnoreCaseAndAlbumTitleIgnoreCaseAndReleaseDate(releaseEntity.artist, releaseEntity.albumTitle, releaseEntity.releaseDate)
-        }
-        .collect()
+    reentrantReadWriteLock.readLock().lock()
+    try {
+      return releaseEntities.unique(false, RELEASE_ENTITY_COMPARATOR)
+          .findAll { releaseEntity ->
+            !releaseRepository.existsByArtistIgnoreCaseAndAlbumTitleIgnoreCaseAndReleaseDate(releaseEntity.artist, releaseEntity.albumTitle, releaseEntity.releaseDate)
+          }
+    }
+    finally {
+      reentrantReadWriteLock.readLock().unlock()
+    }
+  }
+
+  private List<ReleaseEntity> save(List<ReleaseEntity> releases) {
+    reentrantReadWriteLock.writeLock().lock()
+    try {
+      releases = releases.findAll { releaseEntity ->
+        !releaseRepository.existsByArtistIgnoreCaseAndAlbumTitleIgnoreCaseAndReleaseDate(releaseEntity.artist, releaseEntity.albumTitle, releaseEntity.releaseDate)
+      }
+      return releaseRepository.saveAll(releases)
+    }
+    finally {
+      reentrantReadWriteLock.writeLock().unlock()
+    }
   }
 
   protected ImportResult finalizeImport(int totalCountRequested, int totalCountImported) {
-    log.info("Import of new releases completed for ${getReleaseSource().displayName}. " +
-            "${totalCountImported} out of ${totalCountRequested} requested releases were imported.")
+    log.info("Import of new releases completed for ${getReleaseSource().displayName}. ${totalCountImported} out of ${totalCountRequested} requested releases were imported.")
     return new ImportResult(
         totalCountRequested: totalCountRequested,
         totalCountImported: totalCountImported

--- a/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/ParallelCoverDownloader.groovy
+++ b/supplier/infrastructure/src/main/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/ParallelCoverDownloader.groovy
@@ -1,36 +1,24 @@
 package rocks.metaldetector.butler.supplier.infrastructure.importjob
 
-import groovy.util.logging.Slf4j
-import jakarta.transaction.Transactional
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.stereotype.Service
 import rocks.metaldetector.butler.persistence.domain.release.ReleaseEntity
-import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
 
 import java.util.concurrent.Future
 import java.util.function.Function
 
-@Slf4j
 @Service
 class ParallelCoverDownloader {
 
   @Autowired
   ThreadPoolTaskExecutor threadPoolTaskExecutor
 
-  @Autowired
-  ReleaseRepository releaseRepository
-
-  @Transactional
-  List<ReleaseEntity> downloadAndSave(List<ReleaseEntity> releaseBatch, Function<ReleaseEntity, Runnable> coverDownloadTask) {
+  void download(List<ReleaseEntity> releaseBatch, Function<ReleaseEntity, Runnable> coverDownloadTask) {
     List<Future> futures = []
-
     releaseBatch.each {
       releaseEntity -> futures << threadPoolTaskExecutor.submit(coverDownloadTask.apply(releaseEntity))
-    }.collect()
-
+    }
     futures*.get()
-    releaseRepository.saveAll(releaseBatch)
-    return releaseBatch
   }
 }

--- a/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/AbstractReleaseImporterTest.groovy
+++ b/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/AbstractReleaseImporterTest.groovy
@@ -85,9 +85,9 @@ class AbstractReleaseImporterTest extends Specification {
     underTest.saveNewReleasesWithCover(releaseEntities)
 
     then:
-    1 * underTest.coverDownloader.download({ args ->
-      args.size() < releaseEntities.size()
-                                           }, _)
+    1 * underTest.coverDownloader.download(
+        { args -> args.size() < releaseEntities.size() }, _
+    )
   }
 
   def "saveNewReleasesWithCover: should call cover downloader per each releases batch"() {

--- a/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/ParallelCoverDownloaderTest.groovy
+++ b/supplier/infrastructure/src/test/groovy/rocks/metaldetector/butler/supplier/infrastructure/importjob/ParallelCoverDownloaderTest.groovy
@@ -1,7 +1,6 @@
 package rocks.metaldetector.butler.supplier.infrastructure.importjob
 
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
-import rocks.metaldetector.butler.persistence.domain.release.ReleaseRepository
 import spock.lang.Specification
 
 import static rocks.metaldetector.butler.supplier.infrastructure.DtoFactory.ReleaseEntityFactory.createReleaseEntity
@@ -9,8 +8,7 @@ import static rocks.metaldetector.butler.supplier.infrastructure.DtoFactory.Rele
 class ParallelCoverDownloaderTest extends Specification {
 
   ParallelCoverDownloader underTest = new ParallelCoverDownloader(
-      threadPoolTaskExecutor: Mock(ThreadPoolTaskExecutor),
-      releaseRepository: Mock(ReleaseRepository)
+      threadPoolTaskExecutor: Mock(ThreadPoolTaskExecutor)
   )
 
   def "should submit CoverDownloadTask for each release"() {
@@ -20,7 +18,7 @@ class ParallelCoverDownloaderTest extends Specification {
     def releaseEntities = [release1, release2]
 
     when:
-    underTest.downloadAndSave(releaseEntities, release -> new CoverDownloadTask(releaseEntity: release))
+    underTest.download(releaseEntities, release -> new CoverDownloadTask(releaseEntity: release))
 
     then:
     1 * underTest.threadPoolTaskExecutor.submit({
@@ -31,19 +29,5 @@ class ParallelCoverDownloaderTest extends Specification {
     1 * underTest.threadPoolTaskExecutor.submit({
       args -> args instanceof CoverDownloadTask && args.releaseEntity == release2
     })
-  }
-
-  def "should call release repository to save all new releases"() {
-    given:
-    def releaseEntities = [
-        createReleaseEntity("a"),
-        createReleaseEntity("b")
-    ]
-
-    when:
-    underTest.downloadAndSave(releaseEntities, release -> () -> {})
-
-    then:
-    1 * underTest.releaseRepository.saveAll(releaseEntities)
   }
 }

--- a/supplier/time-for-metal/src/test/groovy/rocks/metaldetector/butler/supplier/timeformetal/importjob/TimeForMetalReleaseImporterTest.groovy
+++ b/supplier/time-for-metal/src/test/groovy/rocks/metaldetector/butler/supplier/timeformetal/importjob/TimeForMetalReleaseImporterTest.groovy
@@ -6,6 +6,8 @@ import rocks.metaldetector.butler.supplier.infrastructure.cover.CoverService
 import rocks.metaldetector.butler.supplier.timeformetal.TimeForMetalWebCrawler
 import spock.lang.Specification
 
+import java.util.concurrent.locks.ReentrantReadWriteLock
+
 import static rocks.metaldetector.butler.supplier.timeformetal.DtoFactory.ReleaseEntityFactory
 
 class TimeForMetalReleaseImporterTest extends Specification {
@@ -14,11 +16,14 @@ class TimeForMetalReleaseImporterTest extends Specification {
       webCrawler: Mock(TimeForMetalWebCrawler),
       timeForMetalReleaseEntityConverter: Mock(Converter),
       timeForMetalCoverService: Mock(CoverService),
-      releaseRepository: Mock(ReleaseRepository)
+      releaseRepository: Mock(ReleaseRepository),
+      reentrantReadWriteLock: Mock(ReentrantReadWriteLock)
   )
 
   def "webCrawler is called with initial page"() {
     given:
+    underTest.reentrantReadWriteLock.readLock() >> Mock(ReentrantReadWriteLock.ReadLock)
+    underTest.reentrantReadWriteLock.writeLock() >> Mock(ReentrantReadWriteLock.WriteLock)
     underTest.timeForMetalReleaseEntityConverter.convert(*_) >> []
     underTest.releaseRepository.saveAll(*_) >> []
 
@@ -31,6 +36,8 @@ class TimeForMetalReleaseImporterTest extends Specification {
 
   def "entityConverter is called with raw release page"() {
     given:
+    underTest.reentrantReadWriteLock.readLock() >> Mock(ReentrantReadWriteLock.ReadLock)
+    underTest.reentrantReadWriteLock.writeLock() >> Mock(ReentrantReadWriteLock.WriteLock)
     def rawPage = "releasePage"
     underTest.webCrawler.requestReleases(*_) >> rawPage
     underTest.releaseRepository.saveAll(*_) >> []
@@ -44,6 +51,8 @@ class TimeForMetalReleaseImporterTest extends Specification {
 
   def "if entityConverter returns new releases webCrawler is called with next page"() {
     given:
+    underTest.reentrantReadWriteLock.readLock() >> Mock(ReentrantReadWriteLock.ReadLock)
+    underTest.reentrantReadWriteLock.writeLock() >> Mock(ReentrantReadWriteLock.WriteLock)
     def firstReleasePage = "releasePage"
     underTest.timeForMetalReleaseEntityConverter.convert(firstReleasePage) >> [ReleaseEntityFactory.createReleaseEntity("a")]
     underTest.timeForMetalReleaseEntityConverter.convert(null) >> []


### PR DESCRIPTION
To really leverage asynchronicity here I used ReadWrite-Locks to improve access to the ReleaseRepository. This does require more database communication but the time won through parallel work should be far more.